### PR TITLE
[WIP] MaterialMatchers: match material(data) to given condition (f.e. all wooden stairs)

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -8,13 +8,14 @@ import org.bukkit.map.MapView;
 import org.bukkit.material.*;
 import org.bukkit.potion.Potion;
 import org.bukkit.util.Java15Compat;
+import org.bukkit.util.matcher.Matcher;
 
 import com.google.common.collect.Maps;
 
 /**
  * An enum of all material IDs accepted by the official server and client
  */
-public enum Material {
+public enum Material implements Matcher<Material> {
     AIR(0, 0),
     STONE(1),
     GRASS(2),
@@ -1082,5 +1083,10 @@ public enum Material {
             default:
                 return false;
         }
+    }
+
+    @Override
+    public boolean matches(Material material) {
+        return this == material;
     }
 }

--- a/src/main/java/org/bukkit/material/MaterialData.java
+++ b/src/main/java/org/bukkit/material/MaterialData.java
@@ -1,12 +1,13 @@
 package org.bukkit.material;
 
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.matcher.Matcher;
 
 /**
  * Handles specific metadata for certain items or blocks
  */
-public class MaterialData implements Cloneable {
+public class MaterialData implements Cloneable, Matcher<MaterialData> {
     private final int type;
     private byte data = 0;
 
@@ -131,5 +132,10 @@ public class MaterialData implements Cloneable {
         } catch (CloneNotSupportedException e) {
             throw new Error(e);
         }
+    }
+
+    @Override
+    public boolean matches(MaterialData object) {
+        return this.equals(object);
     }
 }

--- a/src/main/java/org/bukkit/material/Materials.java
+++ b/src/main/java/org/bukkit/material/Materials.java
@@ -1,0 +1,87 @@
+package org.bukkit.material;
+
+import org.bukkit.Material;
+import org.bukkit.util.matcher.Matcher;
+import org.bukkit.util.matcher.MatcherOr;
+
+/**
+ * Default Materials(Data) matchers
+ */
+public enum Materials implements Matcher<Material> {
+
+    // Stairs
+    BRICK_STAIRS(Material.BRICK_STAIRS, Material.NETHER_BRICK_STAIRS),
+    WOODEN_STAIRS(Material.ACACIA_STAIRS, Material.BIRCH_WOOD_STAIRS, Material.DARK_OAK_STAIRS, Material.JUNGLE_WOOD_STAIRS, Material.SPRUCE_WOOD_STAIRS, Material.WOOD_STAIRS),
+    STAIRS(WOODEN_STAIRS, BRICK_STAIRS, Material.COBBLESTONE_STAIRS, Material.COBBLESTONE_STAIRS, Material.SMOOTH_STAIRS, Material.QUARTZ_STAIRS, Material.SANDSTONE_STAIRS),
+
+    //Doors
+    WOODEN_DOORS(Material.WOODEN_DOOR, Material.WOOD_DOOR),
+    IRON_DOORS(Material.IRON_DOOR, Material.IRON_DOOR_BLOCK),
+    DOORS(WOODEN_DOORS, IRON_DOORS),
+
+    //Trapdoors
+    WOODEN_TRAPDOORS(Material.TRAP_DOOR),
+    TRAPDOORS(WOODEN_TRAPDOORS),
+
+    //Tools
+    PICKAXES(Material.WOOD_PICKAXE, Material.STONE_PICKAXE, Material.IRON_PICKAXE, Material.GOLD_PICKAXE, Material.DIAMOND_PICKAXE),
+    SPADES(Material.WOOD_SPADE, Material.STONE_SPADE, Material.IRON_SPADE, Material.GOLD_SPADE, Material.DIAMOND_SPADE),
+    AXES(Material.WOOD_AXE, Material.STONE_AXE, Material.IRON_AXE, Material.GOLD_AXE, Material.DIAMOND_AXE),
+    HOES(Material.WOOD_HOE, Material.STONE_HOE, Material.IRON_HOE, Material.GOLD_HOE, Material.DIAMOND_HOE),
+    TOOLS(PICKAXES, SPADES, AXES, HOES),
+
+    BLOCKS(new BlockMatcher()),
+
+    //Liquids and Buckets
+    WATER_LIQUIDS(Material.WATER, Material.STATIONARY_WATER),
+    LAVA_LIQUIDS(Material.LAVA, Material.STATIONARY_LAVA),
+    LIQUIDS(WATER_LIQUIDS, LAVA_LIQUIDS),
+    FILLED_BUCKETS(Material.LAVA_BUCKET, Material.MILK_BUCKET, Material.WATER_BUCKET),
+    BUCKETS(Material.BUCKET, FILLED_BUCKETS),
+
+    //Fishes
+    //see below
+    FISHES(Material.COOKED_FISH, Material.RAW_FISH);
+
+
+    //Fishes
+    public static final Matcher<MaterialData> NORMAL_RAW_FISH = new MaterialData(Material.RAW_FISH, (byte) 0);
+    public static final Matcher<MaterialData> RAW_SALMON = new MaterialData(Material.RAW_FISH, (byte) 1);
+    public static final Matcher<MaterialData> PUFFER_FISH = new MaterialData(Material.RAW_FISH, (byte) 2);
+    public static final Matcher<MaterialData> CLOWN_FISH = new MaterialData(Material.RAW_FISH, (byte) 3);
+
+    public static final Matcher<MaterialData> NORMAL_COOKED_FISH = new MaterialData(Material.COOKED_FISH, (byte) 0);
+    public static final Matcher<MaterialData> COOKED_SALMON = new MaterialData(Material.COOKED_FISH, (byte) 1);
+
+    //Woods
+    public static final Matcher<MaterialData> OAK_WOOD = new MaterialData(Material.WOOD, (byte) 0);
+    public static final Matcher<MaterialData> SPRUCE_WOOD = new MaterialData(Material.WOOD, (byte) 1);
+    public static final Matcher<MaterialData> BIRCH_WOOD = new MaterialData(Material.WOOD, (byte) 2);
+    public static final Matcher<MaterialData> JUNGLE_WOOD = new MaterialData(Material.WOOD, (byte) 3);
+    public static final Matcher<MaterialData> ACACIA_WOOD = new MaterialData(Material.WOOD, (byte) 4);
+    public static final Matcher<MaterialData> DARK_OAK_WOOD = new MaterialData(Material.WOOD, (byte) 5);
+
+    /////////////////////////////////////////////////////////////
+    //Implementation
+    private Matcher<Material> internMatcher;
+
+    Materials(Matcher<Material>... or) {
+        this(new MatcherOr<Material>(or));
+    }
+
+    Materials(Matcher<Material> exact) {
+        internMatcher = exact;
+    }
+
+    @Override
+    public boolean matches(Material object) {
+        return internMatcher.matches(object);
+    }
+
+    private static class BlockMatcher implements Matcher<Material> {
+        @Override
+        public boolean matches(Material object) {
+            return object.isBlock();
+        }
+    }
+}

--- a/src/main/java/org/bukkit/util/matcher/Matcher.java
+++ b/src/main/java/org/bukkit/util/matcher/Matcher.java
@@ -1,0 +1,16 @@
+package org.bukkit.util.matcher;
+
+/**
+ * A matcher checks whether an object matches the group(s), properties, etc. defined by this matcher.
+ *
+ * @param <T> the type of the object that can be matched against this Matcher
+ */
+public interface Matcher<T> {
+    /**
+     * Checks whether the given object matches thee group(s), properties, etc. defined by this matcher.
+     *
+     * @param object the object to check
+     * @return true if it matches, false otherwise
+     */
+    public boolean matches(T object);
+}

--- a/src/main/java/org/bukkit/util/matcher/MatcherOr.java
+++ b/src/main/java/org/bukkit/util/matcher/MatcherOr.java
@@ -1,0 +1,23 @@
+package org.bukkit.util.matcher;
+
+/**
+ * Simple matcher returning true when one of the given matcher returns true.
+ *
+ * @param <T> the type of the object that can be matched
+ */
+public class MatcherOr<T> implements Matcher<T> {
+    private final Matcher<T>[] elements;
+
+    public MatcherOr(Matcher<T>... elements) {
+        this.elements = elements;
+    }
+
+    @Override
+    public boolean matches(T object) {
+        for (Matcher<T> element : elements)
+            if (element.matches(object))
+                return true;
+
+        return false;
+    }
+}


### PR DESCRIPTION
While the Material enum grows and grows, there's the need for some kind of grouping Materials.

For now, we have to stick to EnchantmentTarget, however, this solution can't be extended for other purposes like to check for (Wooden)Stairs or even plugin-custom filters.

So (especially with the new updates for MC with more and more blocks) I started writing this little classes, to easily group Materials. It can also be used for some MaterialData (f.e. checking for salmon/pufferfish/clownfish) or any other object, f.e. ItemStack (there could be Matchers for finding ItemStacks containing max amount(64/16/1), durability (deterioration, data, ...)) and so on.

This adds just some features to the Bukkit-API, no plugin breaking nor must it be used with Glowstone.
It's not finished yet (only a few Material-Matcher in Materials), but I'd like to get some feedback before I (or everyone who likes) continues this.
