### PR TITLE
Remove BukkitRunnable methods from scheduler

### DIFF
--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -20,12 +20,6 @@ public interface BukkitScheduler {
     public int scheduleSyncDelayedTask(Plugin plugin, Runnable task, long delay);
 
     /**
-     * @deprecated Use {@link BukkitRunnable#runTaskLater(Plugin, long)}
-     */
-    @Deprecated
-    public int scheduleSyncDelayedTask(Plugin plugin, BukkitRunnable task, long delay);
-
-    /**
      * Schedules a once off task to occur as soon as possible.
      * <p>
      * This task will be executed by the main server thread.
@@ -35,12 +29,6 @@ public interface BukkitScheduler {
      * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleSyncDelayedTask(Plugin plugin, Runnable task);
-
-    /**
-     * @deprecated Use {@link BukkitRunnable#runTask(Plugin)}
-     */
-    @Deprecated
-    public int scheduleSyncDelayedTask(Plugin plugin, BukkitRunnable task);
 
     /**
      * Schedules a repeating task.
@@ -54,12 +42,6 @@ public interface BukkitScheduler {
      * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleSyncRepeatingTask(Plugin plugin, Runnable task, long delay, long period);
-
-    /**
-     * @deprecated Use {@link BukkitRunnable#runTaskTimer(Plugin, long, long)}
-     */
-    @Deprecated
-    public int scheduleSyncRepeatingTask(Plugin plugin, BukkitRunnable task, long delay, long period);
 
     /**
      * <b>Asynchronous tasks should never access any API in Bukkit. Great care
@@ -207,12 +189,6 @@ public interface BukkitScheduler {
     public BukkitTask runTask(Plugin plugin, Runnable task) throws IllegalArgumentException;
 
     /**
-     * @deprecated Use {@link BukkitRunnable#runTask(Plugin)}
-     */
-    @Deprecated
-    public BukkitTask runTask(Plugin plugin, BukkitRunnable task) throws IllegalArgumentException;
-
-    /**
      * <b>Asynchronous tasks should never access any API in Bukkit. Great care
      * should be taken to assure the thread-safety of asynchronous tasks.</b>
      * <p>
@@ -227,12 +203,6 @@ public interface BukkitScheduler {
     public BukkitTask runTaskAsynchronously(Plugin plugin, Runnable task) throws IllegalArgumentException;
 
     /**
-     * @deprecated Use {@link BukkitRunnable#runTaskAsynchronously(Plugin)}
-     */
-    @Deprecated
-    public BukkitTask runTaskAsynchronously(Plugin plugin, BukkitRunnable task) throws IllegalArgumentException;
-
-    /**
      * Returns a task that will run after the specified number of server
      * ticks.
      *
@@ -244,12 +214,6 @@ public interface BukkitScheduler {
      * @throws IllegalArgumentException if task is null
      */
     public BukkitTask runTaskLater(Plugin plugin, Runnable task, long delay) throws IllegalArgumentException;
-
-    /**
-     * @deprecated Use {@link BukkitRunnable#runTaskLater(Plugin, long)}
-     */
-    @Deprecated
-    public BukkitTask runTaskLater(Plugin plugin, BukkitRunnable task, long delay) throws IllegalArgumentException;
 
     /**
      * <b>Asynchronous tasks should never access any API in Bukkit. Great care
@@ -268,12 +232,6 @@ public interface BukkitScheduler {
     public BukkitTask runTaskLaterAsynchronously(Plugin plugin, Runnable task, long delay) throws IllegalArgumentException;
 
     /**
-     * @deprecated Use {@link BukkitRunnable#runTaskLaterAsynchronously(Plugin, long)}
-     */
-    @Deprecated
-    public BukkitTask runTaskLaterAsynchronously(Plugin plugin, BukkitRunnable task, long delay) throws IllegalArgumentException;
-
-    /**
      * Returns a task that will repeatedly run until cancelled, starting after
      * the specified number of server ticks.
      *
@@ -286,12 +244,6 @@ public interface BukkitScheduler {
      * @throws IllegalArgumentException if task is null
      */
     public BukkitTask runTaskTimer(Plugin plugin, Runnable task, long delay, long period) throws IllegalArgumentException;
-
-    /**
-     * @deprecated Use {@link BukkitRunnable#runTaskTimer(Plugin, long, long)}
-     */
-    @Deprecated
-    public BukkitTask runTaskTimer(Plugin plugin, BukkitRunnable task, long delay, long period) throws IllegalArgumentException;
 
     /**
      * <b>Asynchronous tasks should never access any API in Bukkit. Great care
@@ -310,10 +262,4 @@ public interface BukkitScheduler {
      * @throws IllegalArgumentException if task is null
      */
     public BukkitTask runTaskTimerAsynchronously(Plugin plugin, Runnable task, long delay, long period) throws IllegalArgumentException;
-
-    /**
-     * @deprecated Use {@link BukkitRunnable#runTaskTimerAsynchronously(Plugin, long, long)}
-     */
-    @Deprecated
-    public BukkitTask runTaskTimerAsynchronously(Plugin plugin, BukkitRunnable task, long delay, long period) throws IllegalArgumentException;
 }


### PR DESCRIPTION
Those methods are deprecated anyway, and it saves us from having to
implement them in Glowstone.
