### PR TITLE
Add API for displaying particle effects

### DIFF
--- a/src/main/java/org/bukkit/Particle.java
+++ b/src/main/java/org/bukkit/Particle.java
@@ -1,0 +1,187 @@
+package org.bukkit;
+
+/**
+ * An enum of particle effects the server is able to send to players.
+ */
+public enum Particle {
+    /**
+     * A very large explosion.
+     */
+    EXPLOSION_HUGE,
+    /**
+     * A large explosion.
+     */
+    EXPLOSION_LARGE,
+    /**
+     * The sparks from fireworks.
+     */
+    FIREWORKS_SPARK,
+    /**
+     * Bubbles. Only displays underwater.
+     */
+    BUBBLES,
+    /**
+     * Underwater ambiance. Only displays underwater.
+     */
+    UNDERWATER,
+    /**
+     * The fog shown in the void.
+     */
+    VOID_FOG,
+    /**
+     * Tiny gray particles.
+     */
+    TOWN_AURA,
+    /**
+     * The critical hit particles.
+     */
+    CRITICAL,
+    /**
+     * Magical critical hit particles.
+     */
+    CRITICAL_MAGIC,
+    /**
+     * Small black smoke particles.
+     */
+    SMOKE,
+    /**
+     * Potion swirls.
+     */
+    SPELL,
+    /**
+     * Semitransparent potion swirls.
+     */
+    SPELL_AMBIENT,
+    /**
+     * A puff of white potion swirls.
+     */
+    SPELL_MOB,
+    /**
+     * A puff of white stars.
+     */
+    SPELL_INSTANT,
+    /**
+     * Purple particles from witches.
+     */
+    SPELL_WITCH,
+    /**
+     * The musical note from note blocks.
+     */
+    NOTE,
+    /**
+     * Nether portal particles.
+     */
+    PORTAL,
+    /**
+     * Enchantment table glyphs.
+     */
+    ENCHANTMENT_TABLE,
+    /**
+     * Small gray smoke particles.
+     */
+    SMOKE_SMALL,
+    /**
+     * Flame particles from mob spawners.
+     */
+    FLAME,
+    /**
+     * The particles that pop out of lava.
+     */
+    LAVA_POP,
+    /**
+     * Footsteps which fade after several seconds.
+     */
+    FOOTSTEP,
+    /**
+     * Water splash particles.
+     */
+    WATER_SPLASH,
+    /**
+     * Large smoke particles.
+     */
+    SMOKE_LARGE,
+    /**
+     * White smoke particles.
+     */
+    CLOUD,
+    /**
+     * Colored dust used for redstone.
+     */
+    REDSTONE,
+    /**
+     * Snowball breaking particles.
+     */
+    SNOWBALL,
+    /**
+     * Water dripping from the ceiling.
+     */
+    DRIP_WATER,
+    /**
+     * Lava dripping from the ceiling.
+     */
+    DRIP_LAVA,
+    /**
+     * Small white puffs.
+     */
+    SNOW_SHOVEL,
+    /**
+     * Slime ball break particles.
+     */
+    SLIME,
+    /**
+     * Hearts from breeding animals.
+     */
+    HEART,
+    /**
+     * Thunderclouds indicating villager anger.
+     */
+    VILLAGER_ANGRY,
+    /**
+     * Green stars indicating villager happiness.
+     */
+    VILLAGER_HAPPY,
+    /**
+     * The wake created while fishing.
+     */
+    WATER_WAKE,
+    /**
+     * The particles generated when a tool breaks.
+     * Requires an item material to be specified.
+     */
+    ITEM_BREAK,
+    /**
+     * The particles generated when a block is broken.
+     * Requires a block material to be specified.
+     */
+    BLOCK_BREAK,
+    /**
+     * Dust textured like a specific block.
+     * Requires a block material to be specified.
+     */
+    BLOCK_DUST,
+    /**
+     * Sprite of the barrier block.
+     */
+    BARRIER,
+    /**
+     * A droplet of water, similar to a splash but not at speed.
+     */
+    WATER_DROPLET,
+    /**
+     * Unknown.
+     */
+    ITEM_TAKE,
+    /**
+     * Shows a vision of a Guardian mob centered on the player's screen,
+     * regardless of position.
+     */
+    MOB_APPEARANCE;
+
+    /**
+     * Whether this particle requires a material to be specified.
+     */
+    public boolean usesMaterial() {
+        return this == ITEM_BREAK || this == BLOCK_BREAK || this == BLOCK_DUST;
+    }
+
+}

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -13,6 +13,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.MaterialData;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.bukkit.util.Vector;
@@ -1154,6 +1155,33 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
+
+    /**
+     * Displays a particle at the provided Location in the World.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param data the data of the particles, sometimes speed
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, float offsetX, float offsetY, float offsetZ, float data, int amount);
+
+    /**
+     * Displays a particle at the provided Location in the World.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param material the {@link MaterialData} of the particle, for some particles
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param data the data of the particles, sometimes speed
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, MaterialData material, float offsetX, float offsetY, float offsetZ, float data, int amount);
 
     /**
      * Represents various map environment types that a world may be

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -10,12 +10,14 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Note;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.Statistic;
 import org.bukkit.WeatherType;
 import org.bukkit.command.CommandSender;
 import org.bukkit.conversations.Conversable;
 import org.bukkit.map.MapView;
+import org.bukkit.material.MaterialData;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.bukkit.scoreboard.Scoreboard;
 
@@ -260,6 +262,33 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param data a data bit needed for some effects
      */
     public <T> void playEffect(Location loc, Effect effect, T data);
+
+    /**
+     * Displays a particle effect to just this player.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param data the data of the particles, sometimes speed
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, float offsetX, float offsetY, float offsetZ, float data, int amount);
+
+    /**
+     * Displays a particle effect to just this player.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param material the {@link MaterialData} of the particle, for some particles
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param data the data of the particles, sometimes speed
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, MaterialData material, float offsetX, float offsetY, float offsetZ, float data, int amount);
 
     /**
      * Send a block change. This fakes a block change packet for a user at a


### PR DESCRIPTION
There is no method to display specific particle effects to the users like there are to play individual sounds (Sound) or special effects (Effect). A wide variety particle effects are not currently possible to display to players, and it would be useful to be able to display them.

A new Particle enum is added to Bukkit, containing the known valid particle effect types. Two showParticles methods each are added to Player and World, to show a particle effect to a single player or nearby players, with or without material data.

The reason for making Particle its own class separate from Effect is twofold. First, the kind of data you need to show a Particle is largely different from that of an Effect. Second, to be parallel to Sound, which is also separate. Sounds and Particles are two kinds of effect to play to the player. The Effect enum contains several special predefined (by Minecraft) combinations of sounds and/or particles.

To address:
- [x] **In 1.8, particles now have int rather than string ids.** The String methods need to be removed.
- [x] `usesMaterial`/`usesData` may now be the same thing.
- [x] The particle list may need to be updated for 1.8.
- [x] [Skipping] How to document specific details about what each argument to showParticle does and to which particles (caveats, so on).
- [x] [Skipping] Potentially adding range-limited methods (NMS's default limit is 16 blocks).
- [x] [Skipping] Unit tests? Sound has no tests and Effect has a trivial, non-applicable test.
- [x] Maybe better validation of MaterialData passed (ITEM_BREAK expects item, other two expect block). No crashes involved, just particles looking silly.
- [x] More descriptive commit message. The current one is just basic info, the real goods are in this PR description.

```
Added API for displaying particle effects.

Particle effects can be played to individual players and players near a
location. The Particle enum defines the available particle effects. Particles
can be displayed in groups with a spread, and some particles make use of a
MaterialData or an extra data float, which defines speed or some other
property of the generated particles.
```

**Testing Results and Materials:**

Testing plugin code: https://gist.github.com/SpaceManiac/8837964
Testing plugin download: http://wombat.platymuus.com/dl/ParticleTest.jar

How to use:
/particles list - displays Particle.values()
/particles all - shows all particle types in sequence to only you
/particles [name] <material> <data> - shows one particle type to all players
All particles are spawned above the player's head (use third person view)

**Relevant PRs:**

https://github.com/GlowstoneMC/Glowstone/commits/particles

B-1024 - https://github.com/Bukkit/Bukkit/pull/1025 - Original Bukkit PR
~~CB-1334 - https://github.com/Bukkit/CraftBukkit/pull/1334 - Accompanying CraftBukkit PR~~

B-802 - https://github.com/Bukkit/Bukkit/pull/802 - Past effort to address this ticket
~~CB-1066 - https://github.com/Bukkit/CraftBukkit/pull/1066 - Past effort to address this ticket~~
