### PR TITLE
TrappedChest's MaterialData should be org.bukkit.material.Chest

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -163,7 +163,7 @@ public enum Material {
     WOOD_BUTTON(143, Button.class),
     SKULL(144, Skull.class),
     ANVIL(145),
-    TRAPPED_CHEST(146),
+    TRAPPED_CHEST(146, Chest.class),
     GOLD_PLATE(147),
     IRON_PLATE(148),
     REDSTONE_COMPARATOR_OFF(149),

--- a/src/main/java/org/bukkit/material/Chest.java
+++ b/src/main/java/org/bukkit/material/Chest.java
@@ -4,7 +4,7 @@ import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 
 /**
- * Represents a (trapped) chest
+ * Represents a chest or trapped chest
  */
 public class Chest extends DirectionalContainer {
 
@@ -57,6 +57,11 @@ public class Chest extends DirectionalContainer {
         super(type, data);
     }
 
+    /**
+     * Gets whether this block is a normal chest or a trapped chest.
+     *
+     * @return false if this is a normal chest, true if it is a trapped chest
+     */
     public boolean isTrappedChest() {
         return this.getItemType() == Material.TRAPPED_CHEST;
     }

--- a/src/main/java/org/bukkit/material/Chest.java
+++ b/src/main/java/org/bukkit/material/Chest.java
@@ -4,12 +4,16 @@ import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 
 /**
- * Represents a chest
+ * Represents a (trapped) chest
  */
 public class Chest extends DirectionalContainer {
 
     public Chest() {
-        super(Material.CHEST);
+        this(false);
+    }
+
+    public Chest(boolean isTrapped) {
+        super(isTrapped ? Material.TRAPPED_CHEST : Material.CHEST);
     }
 
     /**
@@ -51,6 +55,10 @@ public class Chest extends DirectionalContainer {
     @Deprecated
     public Chest(final Material type, final byte data) {
         super(type, data);
+    }
+
+    public boolean isTrappedChest() {
+        return this.getItemType() == Material.TRAPPED_CHEST;
     }
 
     @Override


### PR DESCRIPTION
It's confusing that TrappedChests don't have `org.material.Chest` as `MaterialData`.
That is IMO a logical mistake and TrappedChests' facing direction can't be changed (by plugins).

This PR changes this without breaking any plugins/sever implementations/etc.

---

_Edited by turt2live_

**Related links:**
- Glowstone: GlowstoneMC/Glowstone#358
  - Glowstone PR is not required for operation/implementation
