### PR TITLE
Update Enchanting inventory to include new slot

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -30,10 +30,10 @@ public enum InventoryType {
      */
     CRAFTING(5,"Crafting"),
     /**
-     * An enchantment table inventory, with one CRAFTING slot and three
+     * An enchantment table inventory, with 2 CRAFTING slots and three
      * enchanting buttons.
      */
-    ENCHANTING(1,"Enchanting"),
+    ENCHANTING(2,"Enchanting"),
     /**
      * A brewing stand inventory, with one FUEL slot and three CRAFTING slots.
      */

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -30,7 +30,7 @@ public enum InventoryType {
      */
     CRAFTING(5,"Crafting"),
     /**
-     * An enchantment table inventory, with 2 CRAFTING slots and three
+     * An enchantment table inventory, with two CRAFTING slots and three
      * enchanting buttons.
      */
     ENCHANTING(2,"Enchanting"),

--- a/src/main/java/org/bukkit/inventory/EnchantingInventory.java
+++ b/src/main/java/org/bukkit/inventory/EnchantingInventory.java
@@ -20,16 +20,16 @@ public interface EnchantingInventory extends Inventory {
     ItemStack getItem();
 
     /**
-     * Set the item in the lapis slot.
+     * Set the item in the resource slot (usually Lapis).
      *
      * @param item The new item
      */
-    void setLapis(ItemStack item);
+    void setResource(ItemStack item);
 
     /**
-     * Get the item in the lapis slot.
+     * Get the item in the resource slot (usually Lapis).
      *
      * @return The current item
      */
-    ItemStack getLapis();
+    ItemStack setResource();
 }

--- a/src/main/java/org/bukkit/inventory/EnchantingInventory.java
+++ b/src/main/java/org/bukkit/inventory/EnchantingInventory.java
@@ -31,5 +31,5 @@ public interface EnchantingInventory extends Inventory {
      *
      * @return The current item
      */
-    ItemStack setResource();
+    ItemStack getResource();
 }

--- a/src/main/java/org/bukkit/inventory/EnchantingInventory.java
+++ b/src/main/java/org/bukkit/inventory/EnchantingInventory.java
@@ -18,4 +18,18 @@ public interface EnchantingInventory extends Inventory {
      * @return The current item.
      */
     ItemStack getItem();
+
+    /**
+     * Set the item in the lapis slot.
+     *
+     * @param item The new item
+     */
+    void setLapis(ItemStack item);
+
+    /**
+     * Get the item in the lapis slot.
+     *
+     * @return The current item
+     */
+    ItemStack getLapis();
 }


### PR DESCRIPTION
Adds a couple convenience methods to EnchantingInventory due to the addition of the 'Lapis' slot, and update the InventoryType to include the new slot.
