### PR TITLE
Add MaterialData for Dirt

### DIFF
--- a/src/main/java/org/bukkit/DirtType.java
+++ b/src/main/java/org/bukkit/DirtType.java
@@ -8,17 +8,16 @@ import com.google.common.collect.Maps;
  * Represents the three different types of dirt.
  */
 public enum DirtType {
-
     /**
-     * Represents the normal dirt.
+     * Represents the regular dirt type.
      */
     NORMAL(0x0),
     /**
-     * Represents the coarse dirt.
+     * Represents the coarse dirt type.
      */
     COARSE(0x1),
     /**
-     * Represents the podzol.
+     * Represents the Podzol dirt type.
      */
     PODZOL(0x2);
 
@@ -30,7 +29,7 @@ public enum DirtType {
     }
 
     /**
-     * Gets the associated data value representing this type
+     * Gets the associated data value representing this type.
      *
      * @return A byte containing the data value of this dirt type
      * @deprecated Magic value
@@ -41,9 +40,9 @@ public enum DirtType {
     }
 
     /**
-     * Gets the DirtType with the given data value
+     * Gets the DirtType with the given data value.
      *
-     * @param data Data value to fetch
+     * @param data The data value to fetch
      * @return The {@link DirtType} representing the given value, or null
      *     if it doesn't exist
      * @deprecated Magic value

--- a/src/main/java/org/bukkit/DirtType.java
+++ b/src/main/java/org/bukkit/DirtType.java
@@ -1,0 +1,61 @@
+package org.bukkit;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+/**
+ * Represents the three different types of dirt.
+ */
+public enum DirtType {
+
+    /**
+     * Represents the normal dirt.
+     */
+    NORMAL(0x0),
+    /**
+     * Represents the coarse dirt.
+     */
+    COARSE(0x1),
+    /**
+     * Represents the podzol.
+     */
+    PODZOL(0x2);
+
+    private final byte data;
+    private final static Map<Byte, DirtType> BY_DATA = Maps.newHashMap();
+
+    private DirtType(final int data) {
+        this.data = (byte) data;
+    }
+
+    /**
+     * Gets the associated data value representing this type
+     *
+     * @return A byte containing the data value of this dirt type
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public byte getData() {
+        return data;
+    }
+
+    /**
+     * Gets the DirtType with the given data value
+     *
+     * @param data Data value to fetch
+     * @return The {@link DirtType} representing the given value, or null
+     *     if it doesn't exist
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public static DirtType getByData(final byte data) {
+        return BY_DATA.get(data);
+    }
+
+    static {
+        for (DirtType dirt : values()) {
+            BY_DATA.put(dirt.data, dirt);
+        }
+    }
+}

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -18,7 +18,7 @@ public enum Material {
     AIR(0, 0),
     STONE(1),
     GRASS(2),
-    DIRT(3),
+    DIRT(3, Dirt.class),
     COBBLESTONE(4),
     WOOD(5, Tree.class),
     SAPLING(6, Tree.class),

--- a/src/main/java/org/bukkit/material/Dirt.java
+++ b/src/main/java/org/bukkit/material/Dirt.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
  * Represents the different types of dirt.
  */
 public class Dirt extends MaterialData {
+
     public Dirt() {
         super(Material.DIRT);
     }
@@ -17,7 +18,6 @@ public class Dirt extends MaterialData {
     }
 
     /**
-     *
      * @deprecated Magic value
      */
     @Deprecated
@@ -30,7 +30,6 @@ public class Dirt extends MaterialData {
     }
 
     /**
-     *
      * @deprecated Magic value
      */
     @Deprecated
@@ -39,7 +38,6 @@ public class Dirt extends MaterialData {
     }
 
     /**
-     *
      * @deprecated Magic value
      */
     @Deprecated
@@ -48,21 +46,21 @@ public class Dirt extends MaterialData {
     }
 
     /**
-     * Gets the current type of this dirt
+     * Gets the current type of this dirt.
      *
-     * @return DirtType of this dirt
+     * @return The type of dirt
      */
     public DirtType getType() {
         return DirtType.getByData(getData());
     }
 
     /**
-     * Sets the type of this dirt
+     * Sets the type of this dirt.
      *
-     * @param dirt New type of this dirt
+     * @param type The new type of dirt
      */
-    public void setType(DirtType dirt) {
-        setData(dirt.getData());
+    public void setType(DirtType type) {
+        setData(type.getData());
     }
 
     @Override

--- a/src/main/java/org/bukkit/material/Dirt.java
+++ b/src/main/java/org/bukkit/material/Dirt.java
@@ -1,0 +1,77 @@
+package org.bukkit.material;
+
+import org.bukkit.DirtType;
+import org.bukkit.Material;
+
+/**
+ * Represents the different types of dirt.
+ */
+public class Dirt extends MaterialData {
+    public Dirt() {
+        super(Material.DIRT);
+    }
+
+    public Dirt(DirtType dirt) {
+        this();
+        setType(dirt);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public Dirt(final int type) {
+        super(type);
+    }
+
+    public Dirt(final Material type) {
+        super(type);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public Dirt(final int type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public Dirt(final Material type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     * Gets the current type of this dirt
+     *
+     * @return DirtType of this dirt
+     */
+    public DirtType getType() {
+        return DirtType.getByData(getData());
+    }
+
+    /**
+     * Sets the type of this dirt
+     *
+     * @param dirt New type of this dirt
+     */
+    public void setType(DirtType dirt) {
+        setData(dirt.getData());
+    }
+
+    @Override
+    public String toString() {
+        return getType() + " " + super.toString();
+    }
+
+    @Override
+    public Dirt clone() {
+        return (Dirt) super.clone();
+    }
+}


### PR DESCRIPTION
This adds the possibility to identify the three types of dirt: normal, coarse and podzol.

---

_Edited by turt2live_

**Related links:**
- Glowstone: None needed
