### PR TITLE
Add MaterialData for Stone

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -16,7 +16,7 @@ import com.google.common.collect.Maps;
  */
 public enum Material {
     AIR(0, 0),
-    STONE(1),
+    STONE(1, Stone.class),
     GRASS(2),
     DIRT(3),
     COBBLESTONE(4),

--- a/src/main/java/org/bukkit/StoneType.java
+++ b/src/main/java/org/bukkit/StoneType.java
@@ -1,0 +1,77 @@
+package org.bukkit;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+/**
+ * Represents the seven different types of stone.
+ */
+public enum StoneType {
+
+    /**
+     * Represents the normal stone.
+     */
+    NORMAL(0x0),
+    /**
+     * Represents the granite.
+     */
+    GRANITE(0x1),
+    /**
+     * Represents the polished granite.
+     */
+    POLISHED_GRANITE(0x2),
+    /**
+     * Represents the diorite.
+     */
+    DIORITE(0x3),
+    /**
+     * Represents the polished diorite.
+     */
+    POLISHED_DIORITE(0x4),
+    /**
+     * Represents the andesite.
+     */
+    ANDESITE(0x5),
+    /**
+     * Represents the polished andesite.
+     */
+    POLISHED_ANDESITE(0x6);
+
+    private final byte data;
+    private final static Map<Byte, StoneType> BY_DATA = Maps.newHashMap();
+
+    private StoneType(final int data) {
+        this.data = (byte) data;
+    }
+
+    /**
+     * Gets the associated data value representing this type
+     *
+     * @return A byte containing the data value of this stone type
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public byte getData() {
+        return data;
+    }
+
+    /**
+     * Gets the StoneType with the given data value
+     *
+     * @param data Data value to fetch
+     * @return The {@link StoneType} representing the given value, or null
+     *     if it doesn't exist
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public static StoneType getByData(final byte data) {
+        return BY_DATA.get(data);
+    }
+
+    static {
+        for (StoneType stone : values()) {
+            BY_DATA.put(stone.data, stone);
+        }
+    }
+}

--- a/src/main/java/org/bukkit/StoneType.java
+++ b/src/main/java/org/bukkit/StoneType.java
@@ -8,7 +8,6 @@ import com.google.common.collect.Maps;
  * Represents the seven different types of stone.
  */
 public enum StoneType {
-
     /**
      * Represents the normal stone.
      */
@@ -46,7 +45,7 @@ public enum StoneType {
     }
 
     /**
-     * Gets the associated data value representing this type
+     * Gets the associated data value representing this type.
      *
      * @return A byte containing the data value of this stone type
      * @deprecated Magic value
@@ -57,9 +56,9 @@ public enum StoneType {
     }
 
     /**
-     * Gets the StoneType with the given data value
+     * Gets the StoneType with the given data value.
      *
-     * @param data Data value to fetch
+     * @param data The data value to fetch
      * @return The {@link StoneType} representing the given value, or null
      *     if it doesn't exist
      * @deprecated Magic value

--- a/src/main/java/org/bukkit/material/Stone.java
+++ b/src/main/java/org/bukkit/material/Stone.java
@@ -1,0 +1,77 @@
+package org.bukkit.material;
+
+import org.bukkit.StoneType;
+import org.bukkit.Material;
+
+/**
+ * Represents the different types of stone.
+ */
+public class Stone extends MaterialData {
+    public Stone() {
+        super(Material.STONE);
+    }
+
+    public Stone(StoneType stone) {
+        this();
+        setType(stone);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public Stone(final int type) {
+        super(type);
+    }
+
+    public Stone(final Material type) {
+        super(type);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public Stone(final int type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public Stone(final Material type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     * Gets the current type of this stone
+     *
+     * @return StoneType of this stone
+     */
+    public StoneType getType() {
+        return StoneType.getByData(getData());
+    }
+
+    /**
+     * Sets the type of this stone
+     *
+     * @param stone New type of this stone
+     */
+    public void setType(StoneType stone) {
+        setData(stone.getData());
+    }
+
+    @Override
+    public String toString() {
+        return getType() + " " + super.toString();
+    }
+
+    @Override
+    public Stone clone() {
+        return (Stone) super.clone();
+    }
+}

--- a/src/main/java/org/bukkit/material/Stone.java
+++ b/src/main/java/org/bukkit/material/Stone.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
  * Represents the different types of stone.
  */
 public class Stone extends MaterialData {
+
     public Stone() {
         super(Material.STONE);
     }
@@ -17,7 +18,6 @@ public class Stone extends MaterialData {
     }
 
     /**
-     *
      * @deprecated Magic value
      */
     @Deprecated
@@ -30,7 +30,6 @@ public class Stone extends MaterialData {
     }
 
     /**
-     *
      * @deprecated Magic value
      */
     @Deprecated
@@ -39,7 +38,6 @@ public class Stone extends MaterialData {
     }
 
     /**
-     *
      * @deprecated Magic value
      */
     @Deprecated
@@ -48,7 +46,7 @@ public class Stone extends MaterialData {
     }
 
     /**
-     * Gets the current type of this stone
+     * Gets the current type of this stone.
      *
      * @return StoneType of this stone
      */
@@ -57,7 +55,7 @@ public class Stone extends MaterialData {
     }
 
     /**
-     * Sets the type of this stone
+     * Sets the type of this stone.
      *
      * @param stone New type of this stone
      */


### PR DESCRIPTION
This allow to identify the seven type of stone blocks: normal, granite, polished granite, diorite, polished diorite, andesite and polished andesite.

---

_Edited by turt2live_

**Related links:**
- Glowstone: None needed
