### PR TITLE
Bug: buttons cannot placed on top/on the bottom of blocks

### DIFF
--- a/src/main/java/org/bukkit/material/Button.java
+++ b/src/main/java/org/bukkit/material/Button.java
@@ -55,8 +55,7 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
     /**
      * Sets the current state of this button
      *
-     * @param bool
-     *            whether or not the button is powered
+     * @param bool whether or not the button is powered
      */
     public void setPowered(boolean bool) {
         setData((byte) (bool ? (getData() | 0x8) : (getData() & ~0x8)));
@@ -71,17 +70,23 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
         byte data = (byte) (getData() & 0x7);
 
         switch (data) {
-        case 0x1:
-            return BlockFace.WEST;
+            case 0x0:
+                return BlockFace.UP;
 
-        case 0x2:
-            return BlockFace.EAST;
+            case 0x1:
+                return BlockFace.WEST;
 
-        case 0x3:
-            return BlockFace.NORTH;
+            case 0x2:
+                return BlockFace.EAST;
 
-        case 0x4:
-            return BlockFace.SOUTH;
+            case 0x3:
+                return BlockFace.NORTH;
+
+            case 0x4:
+                return BlockFace.SOUTH;
+
+            case 0x5:
+                return BlockFace.DOWN;
         }
 
         return null;
@@ -94,21 +99,29 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
         byte data = (byte) (getData() & 0x8);
 
         switch (face) {
-        case EAST:
-            data |= 0x1;
-            break;
+            case DOWN:
+                data |= 0x0;
+                break;
 
-        case WEST:
-            data |= 0x2;
-            break;
+            case EAST:
+                data |= 0x1;
+                break;
 
-        case SOUTH:
-            data |= 0x3;
-            break;
+            case WEST:
+                data |= 0x2;
+                break;
 
-        case NORTH:
-            data |= 0x4;
-            break;
+            case SOUTH:
+                data |= 0x3;
+                break;
+
+            case NORTH:
+                data |= 0x4;
+                break;
+
+            case UP:
+                data |= 0x5;
+                break;
         }
 
         setData(data);

--- a/src/main/java/org/bukkit/material/Button.java
+++ b/src/main/java/org/bukkit/material/Button.java
@@ -70,23 +70,23 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
         byte data = (byte) (getData() & 0x7);
 
         switch (data) {
-            case 0x0:
-                return BlockFace.UP;
+        case 0x0:
+            return BlockFace.UP;
 
-            case 0x1:
-                return BlockFace.WEST;
+        case 0x1:
+            return BlockFace.WEST;
 
-            case 0x2:
-                return BlockFace.EAST;
+        case 0x2:
+            return  BlockFace.EAST;
 
-            case 0x3:
-                return BlockFace.NORTH;
+        case 0x3:
+            return BlockFace.NORTH;
 
-            case 0x4:
-                return BlockFace.SOUTH;
+        case 0x4:
+            return BlockFace.SOUTH;
 
-            case 0x5:
-                return BlockFace.DOWN;
+        case 0x5:
+            return BlockFace.DOWN;
         }
 
         return null;
@@ -99,29 +99,29 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
         byte data = (byte) (getData() & 0x8);
 
         switch (face) {
-            case DOWN:
-                data |= 0x0;
-                break;
+        case DOWN:
+            data |= 0x0;
+            break;
 
-            case EAST:
-                data |= 0x1;
-                break;
+        case EAST:
+            data |= 0x1;
+            break;
 
-            case WEST:
-                data |= 0x2;
-                break;
+        case WEST:
+            data |= 0x2;
+            break;
 
-            case SOUTH:
-                data |= 0x3;
-                break;
+        case SOUTH:
+            data |= 0x3;
+            break;
 
-            case NORTH:
-                data |= 0x4;
-                break;
+        case NORTH:
+            data |= 0x4;
+            break;
 
-            case UP:
-                data |= 0x5;
-                break;
+        case UP:
+            data |= 0x5;
+            break;
         }
 
         setData(data);

--- a/src/main/java/org/bukkit/material/Button.java
+++ b/src/main/java/org/bukkit/material/Button.java
@@ -77,7 +77,7 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
             return BlockFace.WEST;
 
         case 0x2:
-            return  BlockFace.EAST;
+            return BlockFace.EAST;
 
         case 0x3:
             return BlockFace.NORTH;


### PR DESCRIPTION
- The bukkit API doesn't allow buttons to be placed on top / on the bottom of blocks.
- If a button is placed so, the attached face / facing direction is null

I decided to change the formatting of the switch, tell me if I have to revert it.

---

_Edited by turt2live_

**Related links:**
- Glowstone: None needed
