### PR TITLE
Dynamic recipe API

### DIFF
--- a/src/main/java/org/bukkit/inventory/DynamicRecipe.java
+++ b/src/main/java/org/bukkit/inventory/DynamicRecipe.java
@@ -41,10 +41,6 @@ public class DynamicRecipe implements Recipe {
         return result != null;
     }
 
-    public void cleanup(ItemStack[] matrix) {
-        matcher.cleanup(matrix, result);
-    }
-
     /**
      * Gets the result of this recipe, given the input of {@link #matches(ItemStack[])}.
      * @return The result of the recipe, or null if it does not match

--- a/src/main/java/org/bukkit/inventory/DynamicRecipe.java
+++ b/src/main/java/org/bukkit/inventory/DynamicRecipe.java
@@ -10,8 +10,16 @@ import org.apache.commons.lang.Validate;
  */
 public class DynamicRecipe implements Recipe {
 
-    private ItemMatcher matcher = new ItemMatcher();
+    private ItemMatcher matcher;
     private ItemStack result;
+
+    public DynamicRecipe() {
+        setMatcher(new ItemMatcher());
+    }
+
+    public DynamicRecipe(ItemMatcher matcher) {
+        setMatcher(matcher);
+    }
 
     /**
      * Sets the {@link ItemMatcher} to be used with this recipe.

--- a/src/main/java/org/bukkit/inventory/DynamicRecipe.java
+++ b/src/main/java/org/bukkit/inventory/DynamicRecipe.java
@@ -1,11 +1,26 @@
 package org.bukkit.inventory;
 
+import org.apache.commons.lang.Validate;
+
 /**
  * Represents a dynamic recipe.
- * These are recipes that have can have different results, depending on the inputs used, rather than a simple matching algorithm. <p>
- * Used for recipes such as Banners, which require item metadata to be copied to an item, along with having a semi-shaped recipe.
+ * These are recipes that have can have different results, depending on the inputs used, rather than a simple matching algorithm.
+ *
+ * <p>Used for recipes such as Banners, which require item metadata to be copied to an item, along with having a semi-shaped recipe.</p>
  */
-public interface DynamicRecipe extends Recipe {
+public class DynamicRecipe implements Recipe {
+
+    private ItemMatcher matcher = new ItemMatcher();
+    private ItemStack result;
+
+    /**
+     * Sets the {@link ItemMatcher} to be used with this recipe.
+     * @param matcher ItemMatcher to use. Must not be null.
+     */
+    public void setMatcher(ItemMatcher matcher) {
+        Validate.notNull(matcher, "Matcher cannot be null.");
+        this.matcher = matcher;
+    }
 
     /**
      * Checks to see if the recipe will match a crafting matrix. This method also prepares {@link #getResult()}
@@ -13,12 +28,21 @@ public interface DynamicRecipe extends Recipe {
      * @param matrix Items on the crafting grid
      * @return Whether the recipe matches the inputs
      */
-    boolean match(ItemStack[] matrix);
+    public boolean matches(ItemStack[] matrix) {
+        result = matcher.getResult(matrix);
+        return result != null;
+    }
+
+    public void cleanup(ItemStack[] matrix) {
+        matcher.cleanup(matrix, result);
+    }
 
     /**
-     * Gets the result of this recipe, given the input of {@link #match(ItemStack[])}.
-     * @return
+     * Gets the result of this recipe, given the input of {@link #matches(ItemStack[])}.
+     * @return The result of the recipe, or null if it does not match
      */
     @Override
-    ItemStack getResult();
+    public ItemStack getResult() {
+        return result;
+    }
 }

--- a/src/main/java/org/bukkit/inventory/DynamicRecipe.java
+++ b/src/main/java/org/bukkit/inventory/DynamicRecipe.java
@@ -1,0 +1,24 @@
+package org.bukkit.inventory;
+
+/**
+ * Represents a dynamic recipe.
+ * These are recipes that have can have different results, depending on the inputs used, rather than a simple matching algorithm. <p>
+ * Used for recipes such as Banners, which require item metadata to be copied to an item, along with having a semi-shaped recipe.
+ */
+public interface DynamicRecipe extends Recipe {
+
+    /**
+     * Checks to see if the recipe will match a crafting matrix. This method also prepares {@link #getResult()}
+     * to return the correct item (including all metadata) for the input.
+     * @param matrix Items on the crafting grid
+     * @return Whether the recipe matches the inputs
+     */
+    boolean match(ItemStack[] matrix);
+
+    /**
+     * Gets the result of this recipe, given the input of {@link #match(ItemStack[])}.
+     * @return
+     */
+    @Override
+    ItemStack getResult();
+}

--- a/src/main/java/org/bukkit/inventory/ItemMatcher.java
+++ b/src/main/java/org/bukkit/inventory/ItemMatcher.java
@@ -10,16 +10,4 @@ public class ItemMatcher {
     public ItemStack getResult(ItemStack[] matrix) {
         return null; // Don't match by default
     }
-
-    /**
-     * Clean the crafting matrix after crafting an item.
-     *
-     * <p>Primarily used in recipes where some of the parts of the recipe need to be preserved.</p>
-     * @param matrix Crafting matrix to clean
-     * @param result Result of the given matrix
-     */
-    public void cleanup(ItemStack[] matrix, ItemStack result) {
-        // Do nothing by default
-    }
-
 }

--- a/src/main/java/org/bukkit/inventory/ItemMatcher.java
+++ b/src/main/java/org/bukkit/inventory/ItemMatcher.java
@@ -1,0 +1,25 @@
+package org.bukkit.inventory;
+
+public class ItemMatcher {
+
+    /**
+     * Get the result for a given crafting matrix.
+     * @param matrix a square matrix of items
+     * @return Result of recipe
+     */
+    public ItemStack getResult(ItemStack[] matrix) {
+        return null; // Don't match by default
+    }
+
+    /**
+     * Clean the crafting matrix after crafting an item.
+     *
+     * <p>Primarily used in recipes where some of the parts of the recipe need to be preserved.</p>
+     * @param matrix Crafting matrix to clean
+     * @param result Result of the given matrix
+     */
+    public void cleanup(ItemStack[] matrix, ItemStack result) {
+        // Do nothing by default
+    }
+
+}


### PR DESCRIPTION
This PR provides the ability for Glowstone as well as modders to create dynamic recipes. These need to access NBT or damage values, and have massive numbers of combinations - making static recipes unhelpful.

The API is purposefully quite bare compared to Shaped and Shapless recipes, so that the implementation is easy.

---

_Edited by turt2live_

**Related links:**
- Glowstone: GlowstoneMC/Glowstone#445
