### PR TITLE
Add spawn change management to PlayerBedLeaveEvent. Adds BUKKIT-1917

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
@@ -10,19 +10,47 @@ import org.bukkit.event.HandlerList;
 public class PlayerBedLeaveEvent extends PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Block bed;
+    private boolean bedSpawnChange;
 
+    @Deprecated
     public PlayerBedLeaveEvent(final Player who, final Block bed) {
+        this(who, bed, true);
+    }
+
+    public PlayerBedLeaveEvent(final Player who, final Block bed, boolean bedSpawnChange) {
         super(who);
         this.bed = bed;
+        this.bedSpawnChange = bedSpawnChange;
     }
 
     /**
-     * Returns the bed block involved in this event.
+     * Returns where the player left bed.
      *
-     * @return the bed block involved in this event
+     * @return where the player left bed
      */
     public Block getBed() {
         return bed;
+    }
+
+    /**
+     * Indicates if the bed spawn location for player will change to {@link
+     * #getBed()} after this event is processed.
+     *
+     * @return true if player spawn location will change; otherwise false
+     */
+    public boolean isBedSpawnChange() {
+        return bedSpawnChange;
+    }
+
+    /**
+     * Control if the bed spawn will be changed for player to {@link
+     * #getBed()} after this event is processed.
+     *
+     * @param bedSpawnChange true to cause the bed spawn to change; false to
+     * keep the current bed spawn for Player
+     */
+    public void setBedSpawnChange(boolean bedSpawnChange) {
+        this.bedSpawnChange = bedSpawnChange;
     }
 
     @Override


### PR DESCRIPTION
Split from GlowstoneMC/Glowkit#3
Original Bukkit PR: Bukkit/Bukkit#785
Additional changes: None
Glowstone implementation: Not done

---

Previously it was not possible to change where the player spawned upon
leaving a bed. This commit changes that.
