### PR TITLE
Add enhancements to brewing. Adds BUKKIT-2441

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
@@ -1,0 +1,26 @@
+package org.bukkit.event.inventory;
+
+import org.bukkit.block.Block;
+import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.inventory.ItemStack;
+
+
+/**
+ * This event is called after an ingredient is consumed in a brewing stand.
+ */
+public class BrewEndEvent extends BrewEvent {
+    private ItemStack ingredient;
+
+    public BrewEndEvent(Block brewer, BrewerInventory contents, ItemStack ingredient) {
+        super(brewer, contents);
+        this.ingredient = ingredient;
+    }
+
+    /**
+     * Returns the ingredient used in this brewing session.
+     * @return The ingredient used as an {@link org.bukkit.inventory.ItemStack}.
+     */
+    public ItemStack getIngredient() {
+        return ingredient;
+    }
+}

--- a/src/main/java/org/bukkit/event/inventory/BrewEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockEvent;
 import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.potion.Potion;
 
 /**
  * Called when the brewing of the contents inside the Brewing Stand is
@@ -27,6 +28,16 @@ public class BrewEvent extends BlockEvent implements Cancellable {
      */
     public BrewerInventory getContents() {
         return contents;
+    }
+
+    public Potion[] getPotions() {
+        Potion[] potions = new Potion[3];
+        for (int i = 0; i < 3; i++) {
+            if (contents.getContents()[i] != null) {
+                potions[i] = Potion.fromItemStack(contents.getContents()[i]);
+            }
+        }
+        return potions;
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
Split from GlowstoneMC/Glowkit#3
Original Bukkit PR: Bukkit/Bukkit#873
Additional changes: None
Glowstone implementation: Not done

---

Previously it was not possible to determine when brewing has ended or what
potions were involved in a brew event. These are required for plugins to
fully deal with brewing in Bukkit.

This commit adds the capability to have that support.
