### PR TITLE
Add TeleportCause to EntityTeleportEvent. Adds BUKKIT-4745

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.TravelAgent;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 /**
  * Called when a non-player entity is about to teleport because it is in
@@ -16,8 +17,17 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     protected boolean useTravelAgent = true;
     protected TravelAgent travelAgent;
 
+    /**
+     * @deprecated Use {@link #EntityPortalEvent(Entity, Location, Location, TravelAgent, TeleportCause)} instead
+     */
+    @Deprecated
     public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta) {
         super(entity, from, to);
+        this.travelAgent = pta;
+    }
+
+    public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta, final TeleportCause cause) {
+        super(entity, from, to, cause);
         this.travelAgent = pta;
     }
 

--- a/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
@@ -3,6 +3,7 @@ package org.bukkit.event.entity;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.util.Vector;
 
 /**
@@ -16,8 +17,18 @@ public class EntityPortalExitEvent extends EntityTeleportEvent {
     private Vector before;
     private Vector after;
 
+    /**
+     * @deprecated Use {@link #EntityPortalExitEvent(Entity, Location, Location, Vector, Vector, TeleportCause)} instead
+     */
+    @Deprecated
     public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after) {
         super(entity, from, to);
+        this.before = before;
+        this.after = after;
+    }
+
+    public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after, final TeleportCause cause) {
+        super(entity, from, to, cause);
         this.before = before;
         this.after = after;
     }

--- a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
@@ -14,12 +14,22 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
     private boolean cancel;
     private Location from;
     private Location to;
+    private TeleportCause cause;
 
+    /**
+     * @deprecated Use {@link #EntityTeleportEvent(Entity, Location, Location, TeleportCause)} instead
+     */
+    @Deprecated
     public EntityTeleportEvent(Entity what, Location from, Location to) {
+        this(what, from, to, TeleportCause.UNKNOWN);
+    }
+
+    public EntityTeleportEvent(Entity what, Location from, Location to, TeleportCause cause) {
         super(what);
         this.from = from;
         this.to = to;
         this.cancel = false;
+        this.cause = cause;
     }
 
     public boolean isCancelled() {
@@ -64,6 +74,39 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
      */
     public void setTo(Location to) {
         this.to = to;
+    }
+
+    /**
+     * Gets the cause for this entity teleportation
+     *
+     * @return Cause this entity teleported for
+     */
+    public TeleportCause getCause() {
+        return cause;
+    }
+
+    public enum TeleportCause {
+        /**
+         * Indicates the teleportation was caused by an Enderman teleporting
+         * himself
+         */
+        ENDERMAN,
+        /**
+         * Indicates the teleportation was caused by an entity entering a
+         * Nether portal
+         */
+        NETHER_PORTAL,
+        /**
+         * Indicates the teleportation was caused by an entity entering an End
+         * portal
+         */
+        END_PORTAL,
+        /**
+         * Indicates the teleportation was caused by an event not covered by
+         * this enum
+         */
+        UNKNOWN,
+        ;
     }
 
     @Override


### PR DESCRIPTION
Split from GlowstoneMC/Glowkit#3
Original Bukkit PR: Bukkit/Bukkit#1002
Additional changes: None
Glowstone implementation: Not done

---

Previously it was not possible to determine why a non-player entity has
teleported. This commit changes that so plugins are able to determine what
has happened.
