### PR TITLE
Add EntityDyeEvent. Adds BUKKIT-3900

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDyeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDyeEvent.java
@@ -1,0 +1,60 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.DyeColor;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when an entity has dye successfully used on them.
+ * <p>
+ * For sheep, this event is called when their wool is dyed. For wolves, this
+ * event is fired when their collar is dyed. Note that this event will not
+ * fire if the dye being used is the same color as the wool or the collar.
+ */
+public class EntityDyeEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel;
+    private DyeColor color;
+
+    public EntityDyeEvent(final Entity entity, final DyeColor color) {
+        super(entity);
+        this.cancel = false;
+        this.color = color;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the DyeColor for this event
+     *
+     * @return the DyeColor for this event
+     */
+    public DyeColor getColor() {
+        return color;
+    }
+
+    /**
+     * Sets the DyeColor for this event
+     *
+     * @param color the DyeColor for this event
+     */
+    public void setColor(DyeColor color) {
+        this.color = color;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
+++ b/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
@@ -2,52 +2,24 @@ package org.bukkit.event.entity;
 
 import org.bukkit.DyeColor;
 import org.bukkit.entity.Sheep;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
  * Called when a sheep's wool is dyed
+ *
+ * @deprecated Use EntityDyeEvent instead
  */
-public class SheepDyeWoolEvent extends EntityEvent implements Cancellable {
+@Deprecated
+public class SheepDyeWoolEvent extends EntityDyeEvent {
     private static final HandlerList handlers = new HandlerList();
-    private boolean cancel;
-    private DyeColor color;
 
     public SheepDyeWoolEvent(final Sheep sheep, final DyeColor color) {
-        super(sheep);
-        this.cancel = false;
-        this.color = color;
-    }
-
-    public boolean isCancelled() {
-        return cancel;
-    }
-
-    public void setCancelled(boolean cancel) {
-        this.cancel = cancel;
+        super(sheep, color);
     }
 
     @Override
     public Sheep getEntity() {
         return (Sheep) entity;
-    }
-
-    /**
-     * Gets the DyeColor the sheep is being dyed
-     *
-     * @return the DyeColor the sheep is being dyed
-     */
-    public DyeColor getColor() {
-        return color;
-    }
-
-    /**
-     * Sets the DyeColor the sheep is being dyed
-     *
-     * @param color the DyeColor the sheep will be dyed
-     */
-    public void setColor(DyeColor color) {
-        this.color = color;
     }
 
     @Override
@@ -58,5 +30,4 @@ public class SheepDyeWoolEvent extends EntityEvent implements Cancellable {
     public static HandlerList getHandlerList() {
         return handlers;
     }
-
 }


### PR DESCRIPTION
Split from GlowstoneMC/Glowkit#3
Original Bukkit PR: Bukkit/Bukkit#827
Additional changes: None
Glowstone implementation: Not done

---

Previously only sheep were handled for being dyed. However, currently
there are other mobs that can be dyed by the player, such as wolves. This
commit adds the event required for detecting those changes as well as
manipulates the existing event to be deprecated and implement this new
event.
