### PR TITLE
Add EntityEquipEvent and EntityPickupItemEvent. Adds BUKKIT-3655

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityEquipEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityEquipEvent.java
@@ -1,0 +1,46 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Thrown when an entity picks up and equips an item from the ground
+ */
+public class EntityEquipEvent extends EntityPickupItemEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final int equipSlot;
+
+    public EntityEquipEvent(final LivingEntity entity, final Item item, final int equipSlot) {
+        super(entity, item, item.getPickupDelay());
+        this.equipSlot = equipSlot;
+    }
+
+    /**
+     * Gets the living entity involved in this event.
+     *
+     * @return LivingEntity
+     */
+    @Override
+    public LivingEntity getEntity() {
+        return (LivingEntity) entity;
+    }
+
+    /**
+     * Gets the raw slot the item was equipped into.
+     *
+     * @return the raw slot where the item was equipped
+     */
+    public int getEquipSlot() {
+        return equipSlot;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
@@ -1,0 +1,57 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Thrown when an entity picks an item up from the ground
+ */
+public class EntityPickupItemEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private final Item item;
+    private boolean cancel = false;
+    private final int remaining;
+
+    public EntityPickupItemEvent(final Entity entity, final Item item, final int remaining) {
+        super(entity);
+        this.item = item;
+        this.remaining = remaining;
+    }
+
+    /**
+     * Gets the Item the entity picked up
+     *
+     * @return the Item the entity picked up
+     */
+    public Item getItem() {
+        return item;
+    }
+
+    /**
+     * Gets the amount remaining on the ground, if any
+     *
+     * @return amount remaining on the ground
+     */
+    public int getRemaining() {
+        return remaining;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Split from GlowstoneMC/Glowkit#3
Original Bukkit PR: Bukkit/Bukkit#777
Additional changes: Documentation changes (minor)
Glowstone implementation: Not done

---

Previously it was not possible to determine when, for example, a skeleton
picked up and equipped a helmet. This is a fairly important feature for
plugins that need to manage entities to ensure balancing in concepts such
as minigames.

This commit resolves the issue by adding the event required to determine
when entities equip items.
