### PR TITLE
Added iron golem holding flower methods. Adds BUKKIT-5440.

### DIFF
--- a/src/main/java/org/bukkit/entity/IronGolem.java
+++ b/src/main/java/org/bukkit/entity/IronGolem.java
@@ -19,4 +19,19 @@ public interface IronGolem extends Golem {
      *     player created, false if you want it to be a natural village golem.
      */
     public void setPlayerCreated(boolean playerCreated);
+
+    /**
+     * Gets whether this iron golem holds flower.
+     *
+     * @return Whether this iron golem holds flower.
+     */
+    public boolean isHoldingFlower();
+
+    /**
+     * Sets whether this iron golem holds flower or not. The flower will
+     * remain in the entity's hand for a limited time.
+     *
+     * @param holdingFlower true for holding a flower, false otherwise
+     */
+    public void setHoldingFlower(boolean holdingFlower);
 }


### PR DESCRIPTION
Split from GlowstoneMC/Glowkit#3
Original Bukkit PR: Bukkit/Bukkit#1039
Additional changes: Documentation changes (minor)
Glowstone implementation: Not done

---

Prior to this commit, it was not possible to modify the iron golem's
flower holding ability. This commit changes that.
