### PR TITLE
Update setResourcePack for 1.8

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -943,23 +943,23 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public float getWalkSpeed();
 
     /**
-     * Request that the player's client download and switch texture packs.
+     * Request that the player's client download and switch resource packs.
      * <p>
-     * The player's client will download the new texture pack asynchronously
+     * The player's client will download the new resource pack asynchronously
      * in the background, and will automatically switch to it once the
-     * download is complete. If the client has downloaded and cached the same
-     * texture pack in the past, it will perform a quick timestamp check over
-     * the network to determine if the texture pack has changed and needs to
-     * be downloaded again. When this request is sent for the very first time
-     * from a given server, the client will first display a confirmation GUI
-     * to the player before proceeding with the download.
+     * download is complete. When this request is sent for the very
+     * first time from a given server, the client will first display a
+     * confirmation GUI to the player before proceeding with the download.
      * <p>
      * Notes:
      * <ul>
-     * <li>Players can disable server textures on their client, in which
+     * <li>Players can disable server resources on their client, in which
      *     case this method will have no affect on them.
-     * <li>There is no concept of resetting texture packs back to default
+     * <li>There is no concept of resetting resource packs back to default
      *     within Minecraft, so players will have to relog to do so.
+     * <li>A {@link org.bukkit.event.player.PlayerResourcePackStatusEvent} will
+     *     be fired afterward, indicating what action the client took with the
+     *     resource pack. The hash will be set to the empty string.
      * </ul>
      *
      * @param url The URL from which the client will download the texture
@@ -978,9 +978,39 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * <p>
      * The player's client will download the new resource pack asynchronously
      * in the background, and will automatically switch to it once the
+     * download is complete. When this request is sent for the very
+     * first time from a given server, the client will first display a
+     * confirmation GUI to the player before proceeding with the download.
+     * <p>
+     * Notes:
+     * <ul>
+     * <li>Players can disable server resources on their client, in which
+     *     case this method will have no affect on them.
+     * <li>There is no concept of resetting resource packs back to default
+     *     within Minecraft, so players will have to relog to do so.
+     * <li>A {@link org.bukkit.event.player.PlayerResourcePackStatusEvent} will
+     *     be fired afterward, indicating what action the client took with the
+     *     resource pack. The hash will be set to the empty string.
+     * </ul>
+     *
+     * @param url The URL from which the client will download the resource
+     *     pack. The string must contain only US-ASCII characters and should
+     *     be encoded as per RFC 1738.
+     * @throws IllegalArgumentException Thrown if the URL is null.
+     * @throws IllegalArgumentException Thrown if the URL is too long. The
+     *     length restriction is an implementation specific arbitrary value.
+     */
+    @Deprecated
+    public void setResourcePack(String url);
+
+    /**
+     * Request that the player's client download and switch resource packs.
+     * <p>
+     * The player's client will download the new resource pack asynchronously
+     * in the background, and will automatically switch to it once the
      * download is complete. If the client has downloaded and cached the same
-     * resource pack in the past, it will perform a quick timestamp check
-     * over the network to determine if the resource pack has changed and
+     * resource pack in the past, it will compare the SHA-1 hash of the file
+     * to the given hash, to determine if the resource pack has changed and
      * needs to be downloaded again. When this request is sent for the very
      * first time from a given server, the client will first display a
      * confirmation GUI to the player before proceeding with the download.
@@ -991,16 +1021,23 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      *     case this method will have no affect on them.
      * <li>There is no concept of resetting resource packs back to default
      *     within Minecraft, so players will have to relog to do so.
+     * <li>A {@link org.bukkit.event.player.PlayerResourcePackStatusEvent} will
+     *     be fired afterward, indicating what action the client took with the
+     *     resource pack. The provided hash can be used to differentiate multiple
+     *     {@link org.bukkit.event.player.PlayerResourcePackStatusEvent}s
      * </ul>
      *
      * @param url The URL from which the client will download the resource
      *     pack. The string must contain only US-ASCII characters and should
      *     be encoded as per RFC 1738.
+     * @param hash The SHA-1 hash of the file to download.
+     * @throws IllegalArgumentException Thrown if the hash is longer than 40 characters
+     * @throws IllegalArgumentException Thrown if the hash is null.
      * @throws IllegalArgumentException Thrown if the URL is null.
      * @throws IllegalArgumentException Thrown if the URL is too long. The
      *     length restriction is an implementation specific arbitrary value.
      */
-    public void setResourcePack(String url);
+    public void setResourcePack(String url, String hash);
 
     /**
      * Gets the Scoreboard displayed to this player

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -1031,14 +1031,14 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param url The URL from which the client will download the resource
      *     pack. The string must contain only US-ASCII characters and should
      *     be encoded as per RFC 1738.
-     * @param hash The SHA-1 hash of the file to download.
+     * @param shaHash The SHA-1 hash of the file to download.
      * @throws IllegalArgumentException Thrown if the hash is longer than 40 characters
      * @throws IllegalArgumentException Thrown if the hash is null.
      * @throws IllegalArgumentException Thrown if the URL is null.
      * @throws IllegalArgumentException Thrown if the URL is too long. The
      *     length restriction is an implementation specific arbitrary value.
      */
-    public void setResourcePack(String url, String hash);
+    public void setResourcePack(String url, String shaHash);
 
     /**
      * Gets the Scoreboard displayed to this player

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -984,6 +984,8 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * <p>
      * Notes:
      * <ul>
+     * <li>This triggers a force refresh of the resource pack, even if the
+     *     client is already using it.
      * <li>Players can disable server resources on their client, in which
      *     case this method will have no affect on them.
      * <li>There is no concept of resetting resource packs back to default
@@ -1000,7 +1002,6 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @throws IllegalArgumentException Thrown if the URL is too long. The
      *     length restriction is an implementation specific arbitrary value.
      */
-    @Deprecated
     public void setResourcePack(String url);
 
     /**

--- a/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
@@ -31,43 +31,24 @@ public class PlayerResourcePackStatusEvent extends PlayerEvent {
          * The resource pack download has succeeded, and the client is now using the resource pack sent to it.
          * This occurs after the resource pack has been downloaded and applied.
          */
-        SUCCESS(0),
+        SUCCESS,
 
         /*
          * The client declined the download.
          * This occurs when the user clicks 'No' at the download prompt.
          */
-        DECLINED(1),
+        DECLINED,
 
         /*
          * The client encountered an error when downloading the specified resource pack.
          * This occurs when the user clicks 'Yes' at the download prompt, but an error occurs.
          */
-        FAILED_DOWNLOAD(2),
+        FAILED_DOWNLOAD,
 
         /*
          * The client accepted the resource pack, but it has not been downloaded yet.
          * This occurs when the user clicks 'Yes' at the download prompt, but an error occurs.
          */
-        ACCEPTED(3);
-
-        private int value;
-        private static Map<Integer, Status> valueLookup = new HashMap<Integer, Status>();
-
-        Status(int value) {
-            this.value = value;
-        }
-
-        static {
-            for (Status s: Status.values()) {
-                valueLookup.put(s.value, s);
-            }
-        }
-
-        public static Status valueOf(int value) {
-            return valueLookup.get(value);
-        }
-
-
+        ACCEPTED;
     }
 }

--- a/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
@@ -21,11 +21,6 @@ public class PlayerResourcePackStatusEvent extends PlayerEvent {
 
     public String getHash() { return hash; }
 
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
     public enum Status {
         /*
          * The resource pack download has succeeded, and the client is now using the resource pack sent to it.
@@ -50,5 +45,14 @@ public class PlayerResourcePackStatusEvent extends PlayerEvent {
          * This occurs when the user clicks 'Yes' at the download prompt, but an error occurs.
          */
         ACCEPTED;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
@@ -1,0 +1,73 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PlayerResourcePackStatusEvent extends PlayerEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final Status status;
+    private final String hash;
+
+    public PlayerResourcePackStatusEvent(final Player player, final Status status, final String hash) {
+        super(player);
+        this.status = status;
+        this.hash = hash;
+    }
+
+    public Status getStatus() { return status; }
+
+    public String getHash() { return hash; }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public enum Status {
+        /*
+         * The resource pack download has succeeded, and the client is now using the resource pack sent to it.
+         * This occurs after the resource pack has been downloaded and applied.
+         */
+        SUCCESS(0),
+
+        /*
+         * The client declined the download.
+         * This occurs when the user clicks 'No' at the download prompt.
+         */
+        DECLINED(1),
+
+        /*
+         * The client encountered an error when downloading the specified resource pack.
+         * This occurs when the user clicks 'Yes' at the download prompt, but an error occurs.
+         */
+        FAILED_DOWNLOAD(2),
+
+        /*
+         * The client accepted the resource pack, but it has not been downloaded yet.
+         * This occurs when the user clicks 'Yes' at the download prompt, but an error occurs.
+         */
+        ACCEPTED(3);
+
+        private int value;
+        private static Map<Integer, Status> valueLookup = new HashMap<Integer, Status>();
+
+        Status(int value) {
+            this.value = value;
+        }
+
+        static {
+            for (Status s: Status.values()) {
+                valueLookup.put(s.value, s);
+            }
+        }
+
+        public static Status valueOf(int value) {
+            return valueLookup.get(value);
+        }
+
+
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
@@ -6,6 +6,9 @@ import org.bukkit.event.HandlerList;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Called when a client reports the status of a resource pack sent to it
+ */
 public class PlayerResourcePackStatusEvent extends PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Status status;
@@ -17,8 +20,20 @@ public class PlayerResourcePackStatusEvent extends PlayerEvent {
         this.hash = hash;
     }
 
+    /**
+     * Gets the status of the resource pack sent to the client.
+     *
+     * @return status A {@link Status} describing the status of the resource pack.
+     */
     public Status getStatus() { return status; }
 
+    /**
+     * Gets the specified hash of the resource pack sent to the client.
+     *
+     * This can be used to identify different resource packs sent to the client.
+     * 
+     * @return hash The hash of the resource pack
+     */
     public String getHash() { return hash; }
 
     public enum Status {


### PR DESCRIPTION
In 1.8, the server now specifies a hash when sending a resource pack request to the client.
In addition, it's now possible to determine whether the client accepted or rejected the request, through a new packet type.

This PR allows `Player#setResourcePack` to be called with a hash, and adds `PlayerResourcePackStatusEvent` to allow plugins to determine the result.

---

_Edited by turt2live_

**Related links:**
- Glowstone: GlowstoneMC/Glowstone#500
