### PR TITLE
Fix order of FireworkEffect to be inline with NBT values

### DIFF
--- a/src/main/java/org/bukkit/FireworkEffect.java
+++ b/src/main/java/org/bukkit/FireworkEffect.java
@@ -33,13 +33,13 @@ public final class FireworkEffect implements ConfigurationSerializable {
          */
         STAR,
         /**
-         * A burst effect.
-         */
-        BURST,
-        /**
          * A creeper-face effect.
          */
         CREEPER,
+        /**
+        * A burst effect.
+        */
+        BURST,
         ;
     }
 


### PR DESCRIPTION
A small fix in the order of the enum, so that a switch/case is not needed when converting a FireworkEffect Type to NBT and vice versa.
