### PR TITLE
Added non-existant player checking to whitelist command

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
@@ -2,6 +2,7 @@ package org.bukkit.command.defaults;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
@@ -72,7 +73,9 @@ public class WhitelistCommand extends VanillaCommand {
                 if (badPerm(sender, "add")) return true;
 
                 OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
-                if (target.getUniqueId() != null) {
+                if (target.getUniqueId().equals(UUID.nameUUIDFromBytes(("OfflinePlayer:" + target.getName()).getBytes()))) {
+                    Command.broadcastCommandMessage(sender, "Could not add player \""+ args[1] + "\" to the white-list");
+                } else {
                     if (target.isWhitelisted()) {
                         sender.sendMessage(target.getName() + " is already on the white-list");
                     } else {
@@ -80,7 +83,7 @@ public class WhitelistCommand extends VanillaCommand {
 
                         Command.broadcastCommandMessage(sender, "Added " + args[1] + " to the white-list");
                     }
-                } else { Command.broadcastCommandMessage(sender, "Could not add "+ args[1] + " to the white-list"); }
+                }
                 return true;
             } else if (args[0].equalsIgnoreCase("remove")) {
                 if (badPerm(sender, "remove")) return true;

--- a/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
@@ -72,15 +72,15 @@ public class WhitelistCommand extends VanillaCommand {
                 if (badPerm(sender, "add")) return true;
 
                 OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
+                if (target.getUniqueId() != null) {
+                    if (target.isWhitelisted()) {
+                        sender.sendMessage(target.getName() + " is already on the white-list");
+                    } else {
+                        target.setWhitelisted(true);
 
-                if (target.isWhitelisted()) {
-                    sender.sendMessage(target.getName() + " is already on the white-list");
-                } else {
-                    target.setWhitelisted(true);
-
-                    Command.broadcastCommandMessage(sender, "Added " + args[1] + " to the white-list");
-                }
-
+                        Command.broadcastCommandMessage(sender, "Added " + args[1] + " to the white-list");
+                    }
+                } else { Command.broadcastCommandMessage(sender, "Could not add "+ args[1] + " to the white-list"); }
                 return true;
             } else if (args[0].equalsIgnoreCase("remove")) {
                 if (badPerm(sender, "remove")) return true;


### PR DESCRIPTION
This commit fixes last problem in https://github.com/GlowstoneMC/Glowstone/issues/523 by checking to ensure that we are not adding a player using a Glowstone-generated UUID rather than the Mojang one.
