### PR TITLE
Add new title-based inventory methods. Adds BUKKIT-1899

### DIFF
--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -350,6 +350,20 @@ public interface Inventory extends Iterable<ItemStack> {
      * @return A String with the title.
      */
     public String getTitle();
+    
+    /**
+     * Sets the title of this inventory. This will have no effect if {@link Inventory#isNameable()} returns false.
+     * 
+     * @param title the new title of this inventory.
+     */
+    public void setTitle(String title);
+
+    /**
+     * Returns whether this inventory is renameable.
+     *
+     * @return whether this inventory is nameable.
+     */
+    public boolean isNameable();
 
     /**
      * Returns what type of inventory this is.

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -350,10 +350,10 @@ public interface Inventory extends Iterable<ItemStack> {
      * @return A String with the title.
      */
     public String getTitle();
-    
+
     /**
      * Sets the title of this inventory. This will have no effect if {@link Inventory#isNameable()} returns false.
-     * 
+     *
      * @param title the new title of this inventory.
      */
     public void setTitle(String title);


### PR DESCRIPTION
Original Bukkit PR: https://github.com/Bukkit/Bukkit/pull/1110

---

Bukkit currently lacks a way to set the title of an inventory through its API, forcing those who wish to implement such a functionality to use (already existing) NMS methods.
