### PR TITLE
Add Merchant Trade API. Adds BUKKIT-5663

### DIFF
--- a/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
+++ b/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
@@ -14,6 +14,7 @@ import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.TradeOffer;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
@@ -33,6 +34,7 @@ public class ConfigurationSerialization {
         registerClass(Color.class);
         registerClass(PotionEffect.class);
         registerClass(FireworkEffect.class);
+        registerClass(TradeOffer.class);
     }
 
     protected ConfigurationSerialization(Class<? extends ConfigurationSerializable> clazz) {

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -1,5 +1,7 @@
 package org.bukkit.entity;
 
+import java.util.Collection;
+
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.inventory.Inventory;
@@ -7,6 +9,8 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.TradeOffer;
+import org.bukkit.merchant.Merchant;
 import org.bukkit.permissions.Permissible;
 
 /**
@@ -88,6 +92,28 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      *     opened.
      */
     public InventoryView openEnchanting(Location location, boolean force);
+
+    /**
+     * Opens a trade inventory window with the player's inventory on the bottom
+     * and the respective offers from the {@link org.bukkit.inventory.MerchantInventory#getOffers()}.
+     *
+     * @param merchant the merchant to trade with
+     * @param force if false, and the merchant is too far away from the player, the
+     *     inventory will be closed if this player is too far
+     * @return the newly opened inventory view, or null if it could not be opened
+     */
+    public InventoryView openTrade(Merchant merchant, boolean force);
+
+    /**
+     * Opens a trade inventory window with the player's inventory on the bottom and
+     * the specified offers listed in said trade inventory window.
+     *
+     * @param offers the offers to send to the player
+     * @param customName The custom name to label the trade window
+     * @return the newly opened inventory view, or null if it could not be opened
+     * @throws IllegalArgumentException if the offers are null
+     */
+    public InventoryView openTrade(Collection<TradeOffer> offers, String customName);
 
     /**
      * Opens an inventory window to the specified inventory view.

--- a/src/main/java/org/bukkit/entity/Villager.java
+++ b/src/main/java/org/bukkit/entity/Villager.java
@@ -1,9 +1,11 @@
 package org.bukkit.entity;
 
+import org.bukkit.merchant.Merchant;
+
 /**
  * Represents a villager NPC
  */
-public interface Villager extends Ageable, NPC {
+public interface Villager extends Ageable, NPC, Merchant {
 
     /**
      * Gets the current profession of this villager.

--- a/src/main/java/org/bukkit/event/merchant/MerchantAddOfferEvent.java
+++ b/src/main/java/org/bukkit/event/merchant/MerchantAddOfferEvent.java
@@ -1,0 +1,66 @@
+package org.bukkit.event.merchant;
+
+import java.util.List;
+
+import org.apache.commons.lang.Validate;
+
+import org.bukkit.merchant.Merchant;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.TradeOffer;
+
+/**
+ * This event is called whenever a TradeOffer is being added to a Merchant's
+ * list of offers. If cancelled, the TradeOffer will not be added to the list.
+ */
+public class MerchantAddOfferEvent extends MerchantEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private List<TradeOffer> offers;
+    private TradeOffer offerToAdd;
+    private boolean cancelled = false;
+
+    public MerchantAddOfferEvent(Merchant merchant, TradeOffer toAdd) {
+        super(merchant);
+        Validate.notNull(toAdd, "Cannot add a null TradeOffer!");
+        this.offers = merchant.getInventory().getOffers();
+        this.offerToAdd = toAdd;
+    }
+
+    /**
+     * Gets an immutable copy of the list of TradeOffers the merchant currently has.
+     *
+     * @return a copy of the current offers from the merchant
+     */
+    public List<TradeOffer> getCurrentOffers() {
+        return offers;
+    }
+
+    /**
+     * Gets the immutable TradeOffer being added to the Merchant's current offers.
+     *
+     * @return the offer to add
+     */
+    public TradeOffer getOfferToAdd() {
+        return offerToAdd;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/event/merchant/MerchantEvent.java
+++ b/src/main/java/org/bukkit/event/merchant/MerchantEvent.java
@@ -1,0 +1,28 @@
+package org.bukkit.event.merchant;
+
+import org.apache.commons.lang.Validate;
+
+import org.bukkit.event.Event;
+import org.bukkit.merchant.Merchant;
+
+/**
+ * Represents a Merchant related event.
+ */
+public abstract class MerchantEvent extends Event {
+
+    protected Merchant merchant;
+
+    MerchantEvent(Merchant merchant) {
+        Validate.notNull(merchant, "Cannot have a null Merchant!");
+        this.merchant = merchant;
+    }
+
+    /**
+     * Gets the merchant involved with this event.
+     *
+     * @return The merchant
+     */
+    public Merchant getMerchant() {
+        return this.merchant;
+    }
+}

--- a/src/main/java/org/bukkit/inventory/MerchantInventory.java
+++ b/src/main/java/org/bukkit/inventory/MerchantInventory.java
@@ -1,4 +1,41 @@
 package org.bukkit.inventory;
 
+import java.util.List;
+
+import org.bukkit.merchant.Merchant;
+
+/**
+ * Represents the inventory of a merchant which contains a list of {@link TradeOffer}s.
+ */
 public interface MerchantInventory extends Inventory {
+
+    /**
+     * Gets the merchant belonging to this inventory
+     *
+     * @return the merchant
+     */
+    public Merchant getMerchant();
+
+    /**
+     * Gets a copy of the offers presented to a Player.
+     *
+     * @return a copied list of TradeOffers being given to the Player
+     */
+    public List<TradeOffer> getOffers();
+
+    /**
+     * Adds the given TradeOffer to this Inventory's list of trade
+     * offers.
+     *
+     * @param offer to add
+     */
+    public void addOffer(TradeOffer offer);
+
+    /**
+     * Removes the specified offer if it is contained within the list of
+     * offers by this inventory.
+     *
+     * @param offer to remove
+     */
+    public void removeOffer(TradeOffer offer);
 }

--- a/src/main/java/org/bukkit/inventory/TradeOffer.java
+++ b/src/main/java/org/bukkit/inventory/TradeOffer.java
@@ -1,0 +1,308 @@
+package org.bukkit.inventory;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang.Validate;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+/**
+ * Represents a Merchant's trade offer that always will have the following:
+ * <ul>
+ *     <li>
+ *         An {@link ItemStack} being bought.
+ *     </li><li>
+ *         A possible second ItemStack being bought.
+ *     </li><li>
+ *         An ItemStack being sold
+ *     </li>
+ *     <li>
+ *         The maxmium amount of times this trade can be used
+ *     </li>
+ * </ul>
+ *
+ * Each TradeOffer has a limited amount of uses. Once the uses have reached
+ * their maximum, the TradeOffer is no longer valid for a player's trade.
+ */
+public final class TradeOffer implements ConfigurationSerializable {
+
+    /**
+     * Gets a builder for building a TradeOffer.
+     *
+     * @return a utility object for building a TradeOffer
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Gets a new builder object with this TradeOffer as a template.
+     * The builder can create a new TradeOffer, but it will be a new instance
+     * of the TradeOffer, not the same TradeOffer.
+     *
+     * @return a new Builder with the TradeOffer as a template for default
+     *     values
+     */
+    public Builder builderOf() {
+        return builder()
+                .withFirstItem(firstItem)
+                .withSecondItem(secondItem)
+                .withResultingItem(resultingOffer)
+                .withSetUses(uses)
+                .withMaxUses(maxUses);
+    }
+
+    /**
+     * This is a builder that allows customizing a TradeOffer before building into
+     * an immutable TradeOffer.
+     *
+     * @see TradeOffer#builder()
+     */
+    public static final class Builder {
+        ItemStack firstItem;
+        ItemStack secondItem;
+        ItemStack resultingOffer;
+        int maxUses = 7;
+        int uses = 0;
+
+        Builder() {}
+
+        /**
+         * Sets the first buying item for the trade offer. The first item in a
+         * TradeOffer cannot be {@link Material#AIR} or null.
+         *
+         * @param itemStack the first buying item
+         * @return this object, for chaining
+         */
+        public Builder withFirstItem(ItemStack itemStack) {
+            Validate.notNull(itemStack, "Cannot have a null item for a TradeOffer's first item!");
+            ItemStack temp = new ItemStack(itemStack);
+            Validate.isTrue(temp.getType() != Material.AIR, "Cannot have an AIR item for a TradeOffer's first item!");
+            this.firstItem = temp;
+            return this;
+        }
+
+        /**
+         * Sets the second buying item for the trade offer. The second item in a
+         * TradeOffer can be null.
+         *
+         * @param itemStack the second buying item
+         * @return this object, for chaining
+         */
+        public Builder withSecondItem(ItemStack itemStack) {
+            if (itemStack == null) {
+                this.secondItem = null;
+                return this;
+            }
+            ItemStack temp = new ItemStack(itemStack);
+            Validate.isTrue(temp.getType() != Material.AIR, "Cannot have an AIR item for a TradeOffer's second item!");
+            this.secondItem = new ItemStack(itemStack);
+            return this;
+        }
+
+        /**
+         * Sets the offered item for the trade offer.
+         *
+         * @param itemStack the resulting offered item
+         * @return this object, for chaining
+         */
+        public Builder withResultingItem(ItemStack itemStack) {
+            Validate.notNull(itemStack, "Cannot have a null item for a TradeOffer's resulting item!");
+            ItemStack temp = new ItemStack(itemStack);
+            Validate.isTrue(temp.getType() != Material.AIR, "Cannot have an AIR item for a TradeOffer's resulting item!");
+            this.resultingOffer = temp;
+            return this;
+        }
+
+        /**
+         * Sets the maximum uses of the trade offer.
+         *
+         * @param uses the maximum uses this TradeOffer will have
+         * @return this object, for chaining
+         */
+        public Builder withMaxUses(int uses) {
+            Validate.isTrue(uses > 0, "Cannot have zero or less than zero uses!");
+            this.maxUses = uses;
+            return this;
+        }
+
+        /**
+         * Sets the current uses of the trade offer.
+         *
+         * @param uses the current uses this TradeOffer will have
+         * @return this object, for chaining
+         */
+        public Builder withSetUses(int uses) {
+            Validate.isTrue(uses >= 0, "Cannot have less than zero uses!");
+            this.uses = uses;
+            return this;
+        }
+
+        /**
+         * Gets a new TradeOffer from the current state of this builder.
+         * </p>
+         * To successfully build, you must have specified at least the
+         * {@link #withFirstItem(ItemStack)} and
+         * {@link #withResultingItem(ItemStack)}
+         *
+         * @return the respective TradeOffer
+         * @throws IllegalStateException if the builder was not set up with the
+         *         proper variables
+         */
+        public TradeOffer build() {
+            if (firstItem == null || resultingOffer == null) {
+                throw new IllegalStateException("Cannot have a null first item or resulting offer item in a TradeOffer!");
+            }
+            return new TradeOffer(this);
+        }
+    }
+
+    private static final String FIRST_ITEM = "first-item";
+    private static final String SECOND_ITEM = "second-item";
+    private static final String BUYING_ITEM = "buying-item";
+    private static final String CURRENT_USES = "current-uses";
+    private static final String MAX_USES = "max-uses";
+
+    private final ItemStack firstItem;
+    private final ItemStack secondItem;
+    private final ItemStack resultingOffer;
+    private final int maxUses;
+    private final int uses;
+
+    TradeOffer(Builder builder) {
+        this.firstItem = builder.firstItem;
+        this.secondItem = builder.secondItem;
+        this.resultingOffer = builder.resultingOffer;
+        this.uses = builder.uses;
+        this.maxUses = builder.maxUses;
+    }
+
+    /**
+     * Gets the first item required by this offer.
+     *
+     * @return the first input item (or left item)
+     */
+    public ItemStack getFirstItem() {
+        return firstItem.clone();
+    }
+
+    /**
+     * Gets a copy of the second ItemStack belonging to this TradeOffer. If there
+     * is no second item, returns null.
+     *
+     * @return the second input item (or right item)
+     * @throws IllegalStateException if the item is null
+     */
+    public ItemStack getSecondItem() {
+        if (!hasSecondItem()) {
+            return null;
+        } else {
+            return secondItem.clone();
+        }
+    }
+
+    /**
+     * Gets the result item for this trade offer.
+     *
+     * @return the item granted by fulfilling this offer
+     */
+    public ItemStack getResultingOffer() {
+        return resultingOffer.clone();
+    }
+
+    /**
+     * Returns true if this offer has a second item requirement.
+     *
+     * @return True if this offer has a second item requirement
+     */
+    public boolean hasSecondItem() {
+        return this.secondItem != null;
+    }
+
+    /**
+     * Returns the current amount of times this offer has been used.
+     *
+     * @return the amount of times this offer has been used
+     */
+    public int getUses() {
+        return this.uses;
+    }
+
+    /**
+     * Returns the maximum times this offer can be used before this offer is
+     * no longer valid.
+     *
+     * @return the maximum uses for this offer
+     */
+    public int getMaxUses() {
+        return this.maxUses;
+    }
+
+    /**
+     * Returns true if this offer is still usable. If false, the offer will no
+     * longer be usable to players and the Merchant will not benefit from this
+     * offer.
+     *
+     * @return true if this offer's uses have exceeded the maximum uses
+     */
+    public boolean hasOfferExpired() {
+        return this.uses >= this.maxUses;
+    }
+
+    /**
+     * @see ConfigurationSerializable
+     */
+    public static ConfigurationSerializable deserialize(Map<String, Object> map) {
+        return builder()
+                .withFirstItem((ItemStack) map.get(FIRST_ITEM))
+                .withSecondItem((ItemStack) map.get(SECOND_ITEM))
+                .withResultingItem((ItemStack) map.get(BUYING_ITEM))
+                .withSetUses((Integer) map.get(CURRENT_USES))
+                .withMaxUses((Integer) map.get(MAX_USES))
+                .build();
+    }
+
+    @Override
+    public Map<String, Object> serialize() {
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
+                .put(FIRST_ITEM, firstItem.clone())
+                .put(BUYING_ITEM, resultingOffer.clone())
+                .put(CURRENT_USES, uses)
+                .put(MAX_USES, maxUses);
+        if (secondItem != null) {
+            builder.put(SECOND_ITEM, secondItem.clone());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public int hashCode() {
+        final int PRIME = 31;
+        int hash = 1;
+        hash = hash * PRIME + firstItem.hashCode();
+        hash = hash * PRIME + (secondItem == null ? 0 : secondItem.hashCode());
+        hash = hash * PRIME + resultingOffer.hashCode();
+        hash = hash * PRIME + uses;
+        hash = hash * PRIME + maxUses;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof TradeOffer)) {
+            return false;
+        }
+        TradeOffer toCheck = (TradeOffer) o;
+        return (this.firstItem.equals(toCheck.firstItem))
+                && (this.resultingOffer.equals(toCheck.resultingOffer))
+                && (this.hasSecondItem() == toCheck.hasSecondItem())
+                && (this.hasSecondItem() ? toCheck.hasSecondItem() && this.secondItem.equals(toCheck.secondItem) : !toCheck.hasSecondItem())
+                && (this.getMaxUses() == toCheck.getMaxUses());
+    }
+}

--- a/src/main/java/org/bukkit/merchant/Merchant.java
+++ b/src/main/java/org/bukkit/merchant/Merchant.java
@@ -1,0 +1,19 @@
+package org.bukkit.merchant;
+
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.MerchantInventory;
+
+/**
+ * Represents a Merchant that is able to trade items with Players.
+ */
+public interface Merchant extends InventoryHolder {
+
+    /**
+     * Gets this Merchant's inventory.
+     *
+     * @return he inventory of the merchant, that also contains all the
+     *     TradeOffers that can be offered to a player
+     */
+    public MerchantInventory getInventory();
+
+}


### PR DESCRIPTION
This commit adds the API required to manipulate a merchant's (villager)
trade options. This also includes the API required to offer a trade to a
player and therefore get some kind of response from a player.

Many new events have been added to help compensate for the lack of
merchant-related events currently available.

---

This still has some formatting work to do before this is fully ready to be implemented. Some additional review from myself is also required.

Thank you @gabizou for your contribution on Bukkit/Bukkit#1077. Hopefully not all is lost and your work may continue here at Glowstone.
