### PR TITLE
[WIP] Fix Javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10</version>
+                <version>2.10.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Glowkit won't compile using the Javadocs executable provided with Java 8. This is a WIP PR to fix it.
