### PR TITLE
Created FusedExplosive interface.

### DIFF
--- a/src/main/java/org/bukkit/entity/Creeper.java
+++ b/src/main/java/org/bukkit/entity/Creeper.java
@@ -3,7 +3,7 @@ package org.bukkit.entity;
 /**
  * Represents a Creeper
  */
-public interface Creeper extends Monster {
+public interface Creeper extends Monster, FusedExplosive {
 
     /**
      * Checks if this Creeper is powered (Electrocuted)
@@ -13,7 +13,8 @@ public interface Creeper extends Monster {
     public boolean isPowered();
 
     /**
-     * Sets the Powered status of this Creeper
+     * Sets the Powered status of this Creeper.<br>
+     * Powered creeper's explosion yield is 2 times bigger than default.
      *
      * @param value New Powered status
      */

--- a/src/main/java/org/bukkit/entity/FusedExplosive.java
+++ b/src/main/java/org/bukkit/entity/FusedExplosive.java
@@ -1,0 +1,21 @@
+package org.bukkit.entity;
+
+/**
+ * A representation of a fused {@link Explosive}.
+ */
+public interface FusedExplosive extends Explosive {
+    /**
+     * Set the number of ticks until the entity blows up after being primed.
+     *
+     * @param fuseTicks The fuse ticks
+     */
+    public void setFuseTicks(int fuseTicks);
+
+    /**
+     * Retrieve the number of ticks until the explosion of this entity.
+     *
+     * @return the number of ticks until this entity explodes
+     */
+    public int getFuseTicks();
+
+}

--- a/src/main/java/org/bukkit/entity/TNTPrimed.java
+++ b/src/main/java/org/bukkit/entity/TNTPrimed.java
@@ -3,22 +3,7 @@ package org.bukkit.entity;
 /**
  * Represents a Primed TNT.
  */
-public interface TNTPrimed extends Explosive {
-
-    /**
-     * Set the number of ticks until the TNT blows up after being primed.
-     *
-     * @param fuseTicks The fuse ticks
-     */
-    public void setFuseTicks(int fuseTicks);
-
-    /**
-     * Retrieve the number of ticks until the explosion of this TNTPrimed
-     * entity
-     *
-     * @return the number of ticks until this TNTPrimed explodes
-     */
-    public int getFuseTicks();
+public interface TNTPrimed extends FusedExplosive {
 
     /**
      * Gets the source of this primed TNT. The source is the entity

--- a/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java
+++ b/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java
@@ -1,9 +1,10 @@
 package org.bukkit.entity.minecart;
 
+import org.bukkit.entity.FusedExplosive;
 import org.bukkit.entity.Minecart;
 
 /**
  * Represents a Minecart with TNT inside it that can explode when triggered.
  */
-public interface ExplosiveMinecart extends Minecart {
+public interface ExplosiveMinecart extends Minecart, FusedExplosive {
 }

--- a/src/main/java/org/bukkit/event/entity/ExplosiveFuseStartEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ExplosiveFuseStartEvent.java
@@ -1,0 +1,53 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.FusedExplosive;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a fused {@link FusedExplosive} is ignited.
+ */
+public class ExplosiveFuseStartEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled = false;
+
+    public ExplosiveFuseStartEvent(FusedExplosive what) {
+        super(what);
+    }
+
+    /**
+     * Gets the {@link FusedExplosive} that was ignited.
+     *
+     * @return The ignited {@link FusedExplosive}
+     */
+    @Override
+    public FusedExplosive getEntity() {
+        return (FusedExplosive) entity;
+    }
+
+    /**
+     * Gets the event's {@link Location}.
+     * @return The event Location
+     */
+    public Location getLocation() {
+        return entity.getLocation ();
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
**The Issue:**

Currently there are no interface similarities between MinecartTNT+Creeper but both entities are Explosives and have a Fuse. It is not possible to specify the explosion range for both of them.

**Justification for this PR:**

Creeper+MinecartTNT are Explosives, but their interface declaration does not specify that.
Both explosives also have a fuse so there is an additional interface for FusedExplosives.

**PR Breakdown:**

This PR add a FusedExplosive interface and add it to all applicable entities. (Creeper, MinecartTNT)
In addition to that it adds the missing ExplosionPrimeEvent to MinecartTNT. (Has not been "Explosive" before)
In adddition to that it adds the ExplosiveFuseStartEvent which is called when the FusedExplosives is fused.

**Testing Results and Materials:**

(Compiled for Bukkit and tested with CraftBukkit)
https://dl.dropboxusercontent.com/u/16999313/Bukkit/FusedExplosivesTest-1.0.jar (Plugin)
https://dl.dropboxusercontent.com/u/16999313/Bukkit/FusedExplosivesTest.zip (Plugin-Sources)

**Old PR(s):**

https://github.com/Bukkit/Bukkit/pull/993
