### PR TITLE
Additions for improved BlockType-system (adds hay, ender-portal-frame, improved lever-facing)

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -187,7 +187,7 @@ public enum Material {
     IRON_TRAP_DOOR(167, TrapDoor.class),
     PRISMARINE(168, Prismarine.class),
     SEA_LANTERN(169),
-    HAY_BLOCK(170),
+    HAY_BLOCK(170, Hay.class),
     CARPET(171),
     HARD_CLAY(172),
     COAL_BLOCK(173),

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -137,7 +137,7 @@ public enum Material {
     BREWING_STAND(117, MaterialData.class),
     CAULDRON(118, Cauldron.class),
     ENDER_PORTAL(119),
-    ENDER_PORTAL_FRAME(120),
+    ENDER_PORTAL_FRAME(120, EnderPortalFrame.class),
     ENDER_STONE(121),
     DRAGON_EGG(122),
     REDSTONE_LAMP_OFF(123),

--- a/src/main/java/org/bukkit/material/EnderPortalFrame.java
+++ b/src/main/java/org/bukkit/material/EnderPortalFrame.java
@@ -1,0 +1,95 @@
+package org.bukkit.material;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+
+public class EnderPortalFrame extends MaterialData implements Directional {
+    public EnderPortalFrame() {
+        super(Material.ENDER_PORTAL_FRAME);
+    }
+
+    /**
+     * @deprecated magic value
+     */
+    public EnderPortalFrame(int type) {
+        super(type);
+    }
+
+    public EnderPortalFrame(Material type) {
+        super(type);
+    }
+
+    /**
+     * @deprecated magic value
+     */
+    public EnderPortalFrame(int type, byte data) {
+        super(type, data);
+    }
+
+    /**
+     * @deprecated magic value
+     */
+    public EnderPortalFrame(Material type, byte data) {
+        super(type, data);
+    }
+
+    /**
+     * Gets whether an EYE_OF_ENDER was placed in this block
+     * @return true if an EYE_OF_ENDER was placed in this block, false otherwise
+     */
+    public boolean hasEye() {
+        return getData() > 3;
+    }
+
+    /**
+     * Sets whether an EYE_OF_ENDER was placed in this block
+     * @param hasEye whether an EYE_OF_ENDER was placed in this block
+     */
+    public void setEye(boolean hasEye) {
+        byte data = getData();
+        if (hasEye)
+            data |= 0x4;
+        else
+            data &= 0x3;
+        setData(data);
+    }
+
+    @Override
+    public void setFacingDirection(BlockFace face) {
+        byte data = (byte) (getData() & 0x4);
+
+        switch (face) {
+            case SOUTH:
+                data |= 0x0;
+                break;
+            case WEST:
+                data |= 0x1;
+                break;
+            case NORTH:
+                data |= 0x2;
+                break;
+            case EAST:
+            default:
+                data |= 0x3;
+                break;
+        }
+
+        setData(data);
+    }
+
+    @Override
+    public BlockFace getFacing() {
+        switch (getData() & 0x3) {
+            case 0:
+                return BlockFace.SOUTH;
+            case 1:
+                return BlockFace.WEST;
+            case 2:
+                return BlockFace.NORTH;
+            case 3:
+                return BlockFace.EAST;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/bukkit/material/EnderPortalFrame.java
+++ b/src/main/java/org/bukkit/material/EnderPortalFrame.java
@@ -1,7 +1,7 @@
 package org.bukkit.material;
 
-import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
+import org.bukkit.Material;
 
 public class EnderPortalFrame extends MaterialData implements Directional {
     public EnderPortalFrame() {
@@ -59,19 +59,19 @@ public class EnderPortalFrame extends MaterialData implements Directional {
         byte data = (byte) (getData() & 0x4);
 
         switch (face) {
-            case SOUTH:
-                data |= 0x0;
-                break;
-            case WEST:
-                data |= 0x1;
-                break;
-            case NORTH:
-                data |= 0x2;
-                break;
-            case EAST:
-            default:
-                data |= 0x3;
-                break;
+        case SOUTH:
+            data |= 0x0;
+            break;
+        case WEST:
+            data |= 0x1;
+            break;
+        case NORTH:
+            data |= 0x2;
+            break;
+        case EAST:
+        default:
+            data |= 0x3;
+            break;
         }
 
         setData(data);
@@ -80,14 +80,14 @@ public class EnderPortalFrame extends MaterialData implements Directional {
     @Override
     public BlockFace getFacing() {
         switch (getData() & 0x3) {
-            case 0:
-                return BlockFace.SOUTH;
-            case 1:
-                return BlockFace.WEST;
-            case 2:
-                return BlockFace.NORTH;
-            case 3:
-                return BlockFace.EAST;
+        case 0:
+            return BlockFace.SOUTH;
+        case 1:
+            return BlockFace.WEST;
+        case 2:
+            return BlockFace.NORTH;
+        case 3:
+            return BlockFace.EAST;
         }
 
         return null;

--- a/src/main/java/org/bukkit/material/EnderPortalFrame.java
+++ b/src/main/java/org/bukkit/material/EnderPortalFrame.java
@@ -92,4 +92,14 @@ public class EnderPortalFrame extends MaterialData implements Directional {
 
         return null;
     }
+
+    @Override
+    public EnderPortalFrame clone() {
+        return (EnderPortalFrame) super.clone();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " with" + (hasEye() ? "" : "out") + " eye of ender facing " + getFacing();
+    }
 }

--- a/src/main/java/org/bukkit/material/EnderPortalFrame.java
+++ b/src/main/java/org/bukkit/material/EnderPortalFrame.java
@@ -3,6 +3,9 @@ package org.bukkit.material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.Material;
 
+/**
+ * Represents an EnderPortalFrame
+ */
 public class EnderPortalFrame extends MaterialData implements Directional {
     public EnderPortalFrame() {
         super(Material.ENDER_PORTAL_FRAME);

--- a/src/main/java/org/bukkit/material/Hay.java
+++ b/src/main/java/org/bukkit/material/Hay.java
@@ -1,7 +1,7 @@
 package org.bukkit.material;
 
-import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
+import org.bukkit.Material;
 
 /**
  * Represents a hay block
@@ -35,31 +35,31 @@ public class Hay extends MaterialData implements Directional {
     @Override
     public void setFacingDirection(BlockFace face) {
         switch (face) {
-            case NORTH:
-            case SOUTH:
-                setData((byte) 8);
-                break;
-            case WEST:
-            case EAST:
-                setData((byte) 4);
-                break;
-            case UP:
-            case DOWN:
-                setData((byte) 0);
-                break;
+        case NORTH:
+        case SOUTH:
+            setData((byte) 8);
+            break;
+        case WEST:
+        case EAST:
+            setData((byte) 4);
+            break;
+        case UP:
+        case DOWN:
+            setData((byte) 0);
+            break;
         }
     }
 
     @Override
     public BlockFace getFacing() {
         switch (getData()) {
-            case 8:
-                return BlockFace.NORTH;
-            case 4:
-                return BlockFace.EAST;
-            case 0:
-            default:
-                return BlockFace.UP;
+        case 8:
+            return BlockFace.NORTH;
+        case 4:
+            return BlockFace.EAST;
+        case 0:
+        default:
+            return BlockFace.UP;
         }
     }
 

--- a/src/main/java/org/bukkit/material/Hay.java
+++ b/src/main/java/org/bukkit/material/Hay.java
@@ -1,0 +1,66 @@
+package org.bukkit.material;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+
+/**
+ * Represents a hay block
+ */
+public class Hay extends MaterialData implements Directional {
+    public Hay(int type) {
+        super(type);
+    }
+
+    public Hay(Material type) {
+        super(type);
+    }
+
+    public Hay(int type, byte data) {
+        super(type, data);
+    }
+
+    public Hay(Material type, byte data) {
+        super(type, data);
+    }
+
+    @Override
+    public void setFacingDirection(BlockFace face) {
+        switch (face) {
+            case NORTH:
+            case SOUTH:
+                setData((byte) 8);
+                break;
+            case WEST:
+            case EAST:
+                setData((byte) 4);
+                break;
+            case UP:
+            case DOWN:
+                setData((byte) 0);
+                break;
+        }
+    }
+
+    @Override
+    public BlockFace getFacing() {
+        switch (getData()) {
+            case 8:
+                return BlockFace.NORTH;
+            case 4:
+                return BlockFace.EAST;
+            case 0:
+            default:
+                return BlockFace.UP;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " facing " + getFacing();
+    }
+
+    @Override
+    public Hay clone() {
+        return (Hay) super.clone();
+    }
+}

--- a/src/main/java/org/bukkit/material/Hay.java
+++ b/src/main/java/org/bukkit/material/Hay.java
@@ -7,6 +7,9 @@ import org.bukkit.block.BlockFace;
  * Represents a hay block
  */
 public class Hay extends MaterialData implements Directional {
+    /**
+     * @deprecated magic value
+     */
     public Hay(int type) {
         super(type);
     }
@@ -15,10 +18,16 @@ public class Hay extends MaterialData implements Directional {
         super(type);
     }
 
+    /**
+     * @deprecated magic value
+     */
     public Hay(int type, byte data) {
         super(type, data);
     }
 
+    /**
+     * @deprecated magic value
+     */
     public Hay(Material type, byte data) {
         super(type, data);
     }

--- a/src/main/java/org/bukkit/material/Lever.java
+++ b/src/main/java/org/bukkit/material/Lever.java
@@ -102,47 +102,76 @@ public class Lever extends SimpleAttachableMaterialData implements Redstone {
         byte data = (byte) (getData() & 0x8);
         BlockFace attach = getAttachedFace();
 
-        if (attach == BlockFace.DOWN) {
-            switch (face) {
-            case SOUTH:
-            case NORTH:
-                data |= 0x5;
-                break;
+        if (face == BlockFace.UP) {
+            switch (attach) {
+                case NORTH:
+                case SOUTH:
+                    data |= 0x5;
+                    break;
 
-            case EAST:
-            case WEST:
-                data |= 0x6;
-                break;
+                case EAST:
+                case WEST:
+                default:
+                    data |= 0x6;
+                    break;
+
             }
-        } else if (attach == BlockFace.UP) {
-            switch (face) {
-            case SOUTH:
-            case NORTH:
-                data |= 0x7;
-                break;
+        } else if (face == BlockFace.DOWN) {
+            switch (attach) {
+                case EAST:
+                case WEST:
+                    data |= 0x0;
+                    break;
 
-            case EAST:
-            case WEST:
-                data |= 0x0;
-                break;
+                case NORTH:
+                case SOUTH:
+                default:
+                    data |= 0x7;
+                    break;
             }
         } else {
-            switch (face) {
-            case EAST:
-                data |= 0x1;
-                break;
+            if (attach == BlockFace.DOWN) {
+                switch (face) {
+                    case SOUTH:
+                    case NORTH:
+                        data |= 0x5;
+                        break;
 
-            case WEST:
-                data |= 0x2;
-                break;
+                    case EAST:
+                    case WEST:
+                        data |= 0x6;
+                        break;
+                }
+            } else if (attach == BlockFace.UP) {
+                switch (face) {
+                    case SOUTH:
+                    case NORTH:
+                        data |= 0x7;
+                        break;
 
-            case SOUTH:
-                data |= 0x3;
-                break;
+                    case EAST:
+                    case WEST:
+                        data |= 0x0;
+                        break;
+                }
+            } else {
+                switch (face) {
+                    case EAST:
+                        data |= 0x1;
+                        break;
 
-            case NORTH:
-                data |= 0x4;
-                break;
+                    case WEST:
+                        data |= 0x2;
+                        break;
+
+                    case SOUTH:
+                        data |= 0x3;
+                        break;
+
+                    case NORTH:
+                        data |= 0x4;
+                        break;
+                }
             }
         }
         setData(data);

--- a/src/main/java/org/bukkit/material/Lever.java
+++ b/src/main/java/org/bukkit/material/Lever.java
@@ -104,74 +104,80 @@ public class Lever extends SimpleAttachableMaterialData implements Redstone {
 
         if (face == BlockFace.UP) {
             switch (attach) {
-                case NORTH:
-                case SOUTH:
-                    data |= 0x5;
-                    break;
+            case NORTH:
+            case SOUTH:
+                data |= 0x5;
+                break;
 
-                case EAST:
-                case WEST:
-                default:
-                    data |= 0x6;
-                    break;
+            case EAST:
+            case WEST:
+            default:
+                data |= 0x6;
+                break;
 
             }
+
+            setData(data);
+            return;
         } else if (face == BlockFace.DOWN) {
             switch (attach) {
-                case EAST:
-                case WEST:
-                    data |= 0x0;
-                    break;
+            case EAST:
+            case WEST:
+                data |= 0x0;
+                break;
 
-                case NORTH:
-                case SOUTH:
-                default:
-                    data |= 0x7;
-                    break;
+            case NORTH:
+            case SOUTH:
+            default:
+                data |= 0x7;
+                break;
+            }
+
+            setData(data);
+            return;
+        }
+
+        if (attach == BlockFace.DOWN) {
+            switch (face) {
+            case SOUTH:
+            case NORTH:
+                data |= 0x5;
+                break;
+
+            case EAST:
+            case WEST:
+                data |= 0x6;
+                break;
+            }
+        } else if (attach == BlockFace.UP) {
+            switch (face) {
+            case SOUTH:
+            case NORTH:
+                data |= 0x7;
+                break;
+
+            case EAST:
+            case WEST:
+                data |= 0x0;
+                break;
             }
         } else {
-            if (attach == BlockFace.DOWN) {
-                switch (face) {
-                    case SOUTH:
-                    case NORTH:
-                        data |= 0x5;
-                        break;
+            switch (face) {
+            case EAST:
+                data |= 0x1;
+                break;
 
-                    case EAST:
-                    case WEST:
-                        data |= 0x6;
-                        break;
-                }
-            } else if (attach == BlockFace.UP) {
-                switch (face) {
-                    case SOUTH:
-                    case NORTH:
-                        data |= 0x7;
-                        break;
+            case WEST:
+                data |= 0x2;
+                break;
 
-                    case EAST:
-                    case WEST:
-                        data |= 0x0;
-                        break;
-                }
-            } else {
-                switch (face) {
-                    case EAST:
-                        data |= 0x1;
-                        break;
+            case SOUTH:
+                data |= 0x3;
+                break;
 
-                    case WEST:
-                        data |= 0x2;
-                        break;
-
-                    case SOUTH:
-                        data |= 0x3;
-                        break;
-
-                    case NORTH:
-                        data |= 0x4;
-                        break;
-                }
+            case NORTH:
+                data |= 0x4;
+                break;
             }
         }
         setData(data);


### PR DESCRIPTION
This changes are needed for this PR: https://github.com/GlowstoneMC/Glowstone/pull/566 (improved Block/ItemType-System).

Adds:
- EnderPortalFrame-MaterialData
- HayBlock-MaterialData

Modifies:
- Lever-MaterialData: setFacingDirection takes now notice of BlockFace.UP/DOWN. Old behaviour was to ignore this values silenty.

---

_Edited by turt2live_
- GlowstoneMC/Glowstone#566
