### PR TITLE
Fix methods for occupied state in Bed MaterialData

### DIFF
--- a/src/main/java/org/bukkit/material/Bed.java
+++ b/src/main/java/org/bukkit/material/Bed.java
@@ -126,28 +126,9 @@ public class Bed extends MaterialData implements Directional {
         }
     }
 
-    /**
-     * Set whether this bed is occupied. Note that this will
-     * only affect one of the two blocks the bed is made of.
-     *
-     * @param isOccupied True to set the bed occupied.
-     */
-    public void setOccupied(boolean isOccupied) {
-        setData((byte) (isOccupied ? (getData() | 0x4) : (getData() & ~0x4)));
-    }
-
-    /**
-     * Determine if this bed is occupied.
-     *
-     * @return true if this bed is occupied, false if it is not
-     */
-    public boolean isOccupied() {
-        return (getData() & 0x4) == 0x4;
-    }
-
     @Override
     public String toString() {
-        return (isOccupied()?"":"UN") + "OCCUPIED " + (isHeadOfBed() ? "HEAD" : "FOOT") + " of " + super.toString() + " facing " + getFacing();
+        return (isHeadOfBed() ? "HEAD" : "FOOT") + " of " + super.toString() + " facing " + getFacing();
     }
 
     @Override

--- a/src/main/java/org/bukkit/material/Bed.java
+++ b/src/main/java/org/bukkit/material/Bed.java
@@ -99,11 +99,7 @@ public class Bed extends MaterialData implements Directional {
             data = 0x3;
         }
 
-        if (isHeadOfBed()) {
-            data |= 0x8;
-        }
-
-        setData(data);
+        setData((byte) (getData() & ~0x3 | data));
     }
 
     /**
@@ -112,7 +108,7 @@ public class Bed extends MaterialData implements Directional {
      * @return the direction the head of the bed is facing
      */
     public BlockFace getFacing() {
-        byte data = (byte) (getData() & 0x7);
+        byte data = (byte) (getData() & 0x3);
 
         switch (data) {
         case 0x0:
@@ -130,9 +126,28 @@ public class Bed extends MaterialData implements Directional {
         }
     }
 
+    /**
+     * Set whether this bed is occupied. Note that this will
+     * only affect one of the two blocks the bed is made of.
+     *
+     * @param isOccupied True to set the bed occupied.
+     */
+    public void setOccupied(boolean isOccupied) {
+        setData((byte) (isOccupied ? (getData() | 0x4) : (getData() & ~0x4)));
+    }
+
+    /**
+     * Determine if this bed is occupied.
+     *
+     * @return true if this bed is occupied, false if it is not
+     */
+    public boolean isOccupied() {
+        return (getData() & 0x4) == 0x4;
+    }
+
     @Override
     public String toString() {
-        return (isHeadOfBed() ? "HEAD" : "FOOT") + " of " + super.toString() + " facing " + getFacing();
+        return (isOccupied()?"":"UN") + "OCCUPIED " + (isHeadOfBed() ? "HEAD" : "FOOT") + " of " + super.toString() + " facing " + getFacing();
     }
 
     @Override


### PR DESCRIPTION
#### The Issue:

Currently there is no way to set whether a bed is occupied. Setting it using `Block.setData(byte)` does not work either (and is deprecated).

Neither is it possible to do this in Glowstone itself as the `setFacingDirection` overrides the the occupied flag and the `getFacingDirection` produces incorrect results due to using a 3 bits mask (`& 0x7`) instead of the necessary 2 bit mask (`& 0x3`).
#### PR Breakdown:

~~This PR adds methods to set and get whether a bed is occupied.~~
It also fixes the `getFacingDirection` method by using the correct bit mask and the `setFacingDirection` by modifying the current data value instead of recalculating it.
All changes should be backwards compatible.

~~While the new methods introduced can be omitted, the fixes for the other two methods are mandatory for correctly implementing beds in Glowstone.~~
