### PR TITLE
Update to Guava 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>10.0.1</version>
+            <version>17.0</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
Glowkit has inherited a very old version of Guava (10.0.1) from Bukkit; since then, Minecraft, Forge, and Spigot, and Sponge have updated to use Guava 17.0. This PR updates Glowkit's version of Guava accordingly.

A large amount of new API has been added from Guava 10 to 17, so this update in Glowkit should help increase compatibility with code originally written for other platforms built on Minecraft (which must use Guava 17 since Minecraft 1.8 uses it, at least not without hacks to bundle multiple versions of the same library).
